### PR TITLE
Only allow importing from the entry point of each package

### DIFF
--- a/packages/athena/package.json
+++ b/packages/athena/package.json
@@ -7,6 +7,14 @@
     "directory": "packages/athena"
   },
   "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "scripts": {
     "test": "echo huzzah!"
   },

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -7,6 +7,14 @@
     "directory": "packages/cache"
   },
   "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "scripts": {
     "test": "echo huzzah!"
   },

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -7,6 +7,14 @@
     "directory": "packages/network"
   },
   "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "scripts": {
     "test": "echo huzzah!"
   },


### PR DESCRIPTION
Setting these `exports` up early, helps prevent folks from importing deeply.
