### PR TITLE
chore: use maintenance, lts and latest versions of node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
# Summary

use maintenance, lts and latest versions of node.

node@12 fails current test cases and is not in maintenance.