### PR TITLE
chore: increase test coverage for @data-eden/network

### DIFF
--- a/packages/network/__tests__/fetch-test.ts
+++ b/packages/network/__tests__/fetch-test.ts
@@ -26,6 +26,8 @@ describe('@data-eden/fetch', function () {
 
   server.events.on('request:unhandled', (req) => {
     console.log('%s %s has no handler', req.method, req.url.href)
+
+    throw new Error('handle unhandled request!');
   })
 
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -48,7 +50,32 @@ describe('@data-eden/fetch', function () {
     return next(request);
   };
 
-  test('basic middleware', async () => {
+  test('should be able to return fetch without middlewares passed', async () => {
+    expect.assertions(2);
+
+    const fetch = buildFetch([]);
+
+    const response = await fetch('http://www.example.com/resource');
+
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toMatchInlineSnapshot(`
+      {
+        "headers": {
+          "headers": {
+            "accept": "*/*",
+            "accept-encoding": "gzip,deflate",
+            "connection": "close",
+            "host": "www.example.com",
+            "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+          },
+          "names": {},
+        },
+        "status": "success",
+      }
+    `);
+  });
+
+  test('should be able to handle basic middleware', async () => {
     expect.assertions(2);
 
     const fetch = buildFetch([noopMiddleware, csrfMiddleware]);
@@ -145,8 +172,6 @@ describe('@data-eden/fetch', function () {
           body: url.searchParams,
         }
       );
-
-      console.log(tunneledRequest);
     
       return next(tunneledRequest);
     };

--- a/packages/network/__tests__/fetch-test.ts
+++ b/packages/network/__tests__/fetch-test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, afterAll, afterEach, expect, test, describe, assert } from 'vitest';
+import { beforeAll, afterAll, afterEach, expect, test, describe } from 'vitest';
 
 import { Response, Request } from 'cross-fetch';
 import { setupServer } from 'msw/node';
@@ -25,10 +25,10 @@ describe('@data-eden/fetch', function () {
   const server = setupServer(...restHandlers);
 
   server.events.on('request:unhandled', (req) => {
-    console.log('%s %s has no handler', req.method, req.url.href)
+    console.log('%s %s has no handler', req.method, req.url.href);
 
     throw new Error('handle unhandled request!');
-  })
+  });
 
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
   afterAll(() => server.close());
@@ -123,14 +123,15 @@ describe('@data-eden/fetch', function () {
   test('should be able to handle errors in middlewares and continuing', async () => {
     expect.assertions(2);
 
-    const failingMiddleware: Middleware = async (
-      request: Request,
-      next: NormalizedFetch
-    ) => {
+    const failingMiddleware: Middleware = () => {
       throw new Error('oh man something happened');
     };
 
-    const fetch = buildFetch([csrfMiddleware, failingMiddleware, noopMiddleware]);
+    const fetch = buildFetch([
+      csrfMiddleware,
+      failingMiddleware,
+      noopMiddleware,
+    ]);
 
     const response = await fetch('http://www.example.com/resource');
 
@@ -164,10 +165,10 @@ describe('@data-eden/fetch', function () {
         // no tunneling needed
         return next(request);
       }
-    
-      let url = new URL(request.url);
+
+      const url = new URL(request.url);
       request.headers.set('X-HTTP-Method-Override', request.method);
-      let tunneledRequest = new Request(
+      const tunneledRequest = new Request(
         `${url.protocol}//${url.hostname}${url.pathname}`,
         {
           method: 'POST',
@@ -175,7 +176,7 @@ describe('@data-eden/fetch', function () {
           body: url.searchParams,
         }
       );
-    
+
       return next(tunneledRequest);
     };
 
@@ -261,6 +262,6 @@ describe('@data-eden/fetch', function () {
         },
         "status": "success",
       }
-    `)
+    `);
   });
 });

--- a/packages/network/__tests__/fetch-test.ts
+++ b/packages/network/__tests__/fetch-test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, afterAll, afterEach, expect, test, describe } from 'vitest';
 
-import { Response } from 'cross-fetch';
+import { Response, Request } from 'cross-fetch';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 
@@ -14,9 +14,19 @@ describe('@data-eden/fetch', function () {
         ctx.json({ status: 'success', headers: req.headers })
       );
     }),
+    rest.post('http://www.example.com/resource/preview', (req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.json({ status: 'success', method: 'POST', headers: req.headers })
+      );
+    }),
   ];
 
   const server = setupServer(...restHandlers);
+
+  server.events.on('request:unhandled', (req) => {
+    console.log('%s %s has no handler', req.method, req.url.href)
+  })
 
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
   afterAll(() => server.close());
@@ -113,5 +123,58 @@ describe('@data-eden/fetch', function () {
           "status": "success",
         }
       `);
-  })
+  });
+
+  test('should be able to change the http method for a given request', async () => {
+    const queryTunneling: Middleware = async (
+      request: Request,
+      next: NormalizedFetch
+    ) => {
+      if (request.url.length <= 10) {
+        // no tunneling needed
+        return next(request);
+      }
+    
+      let url = new URL(request.url);
+      request.headers.set('X-HTTP-Method-Override', request.method);
+      let tunneledRequest = new Request(
+        `${url.protocol}//${url.hostname}${url.pathname}`,
+        {
+          method: 'POST',
+          headers: request.headers,
+          body: url.searchParams,
+        }
+      );
+
+      console.log(tunneledRequest);
+    
+      return next(tunneledRequest);
+    };
+
+    const fetch = buildFetch([csrfMiddleware, queryTunneling, noopMiddleware]);
+
+    const response = await fetch('http://www.example.com/resource/preview');
+
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toMatchInlineSnapshot(`
+      {
+        "headers": {
+          "headers": {
+            "accept": "*/*",
+            "accept-encoding": "gzip,deflate",
+            "connection": "close",
+            "content-length": "0",
+            "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
+            "host": "www.example.com",
+            "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+            "x-csrf": "a totally legit request",
+            "x-http-method-override": "GET",
+          },
+          "names": {},
+        },
+        "method": "POST",
+        "status": "success",
+      }
+    `);
+  });
 });

--- a/packages/network/__tests__/fetch-test.ts
+++ b/packages/network/__tests__/fetch-test.ts
@@ -82,4 +82,36 @@ describe('@data-eden/fetch', function () {
 
     expect(await response.text()).toMatchInlineSnapshot('"We overrode fetch!"');
   });
+
+  test('should be able to handle errors in middlewares and continuing', async () => {
+
+    const failingMiddleware: Middleware = async (
+      request: Request,
+      next: NormalizedFetch
+    ) => {
+      throw new Error('oh man something happened');
+    };
+
+    const fetch = buildFetch([csrfMiddleware, failingMiddleware, noopMiddleware]);
+
+    const response = await fetch('http://www.example.com/resource');
+
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toMatchInlineSnapshot(`
+        {
+          "headers": {
+            "headers": {
+              "accept": "*/*",
+              "accept-encoding": "gzip,deflate",
+              "connection": "close",
+              "host": "www.example.com",
+              "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+              "x-csrf": "a totally legit request",
+            },
+            "names": {},
+          },
+          "status": "success",
+        }
+      `);
+  })
 });

--- a/packages/network/src/fetch.ts
+++ b/packages/network/src/fetch.ts
@@ -39,7 +39,12 @@ function combine(
   middleware: Middleware
 ): NormalizedFetch {
   return async (request: Request) => {
-    return middleware(request, next);
+    return middleware(request, next)
+      .catch((ex: unknown) => {
+        console.error('Middleware failed with the following error', ex);
+      }).then(() => {
+        return next(request);
+      });
   };
 }
 

--- a/packages/network/src/fetch.ts
+++ b/packages/network/src/fetch.ts
@@ -39,15 +39,7 @@ function combine(
   middleware: Middleware
 ): NormalizedFetch {
   return async (request: Request) => {
-    return middleware(request, next)
-      .catch((ex: unknown) => {
-        console.error('Middleware failed with the following error', ex);
-      })
-      .then((response) => {
-        // for failed requests we will continue down the chain
-        // for resolved middlewares we will return the results
-        return response || next(request);
-      });
+    return middleware(request, next);
   };
 }
 

--- a/packages/network/src/fetch.ts
+++ b/packages/network/src/fetch.ts
@@ -42,9 +42,11 @@ function combine(
     return middleware(request, next)
       .catch((ex: unknown) => {
         console.error('Middleware failed with the following error', ex);
-      }).then(() => {
-        return next(request);
-      });
+      }).then((response) => {
+        // for failed requests we will continue down the chain
+        // for resolved middlewares we will return the results
+        return response || next(request);
+      })
   };
 }
 

--- a/packages/network/src/fetch.ts
+++ b/packages/network/src/fetch.ts
@@ -42,11 +42,12 @@ function combine(
     return middleware(request, next)
       .catch((ex: unknown) => {
         console.error('Middleware failed with the following error', ex);
-      }).then((response) => {
+      })
+      .then((response) => {
         // for failed requests we will continue down the chain
         // for resolved middlewares we will return the results
         return response || next(request);
-      })
+      });
   };
 }
 


### PR DESCRIPTION
Addresses part of #16 

- [ ] add tests for a middleware to handle errors in following middlewares (and "recovering")
- [x] add cases where HTTP method is changed by the middleware (aka "query tunneling")
- [x] calling `buildFetch([])` (e.g. when you don't have any middlewares)
- [x] calling `buildFetch` with a few different middlewares that rely on ordering, and assert that they are called in the correct order
- [ ] calling `buildFetch` multiple times makes the first call throw a custom error