### PR TITLE
Remove `prettier` integration from eslint setup.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,8 +6,7 @@ module.exports = {
     ecmaVersion: 2020,
     sourceType: 'module',
   },
-  plugins: ['prettier'],
-  extends: ['eslint:recommended', 'plugin:prettier/recommended'],
+  extends: ['eslint:recommended', 'prettier'],
   rules: {},
   overrides: [
     // node files

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "eslint": "^8.17.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^4.0.0",
         "lint-staged": "^13.0.1",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.6.2",
@@ -2438,26 +2437,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "7.1.1",
       "dev": true,
@@ -2614,11 +2593,6 @@
       "version": "3.1.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-diff": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -5889,17 +5863,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -9459,13 +9422,6 @@
         }
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
-      }
-    },
     "eslint-scope": {
       "version": "7.1.1",
       "dev": true,
@@ -9558,10 +9514,6 @@
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true
-    },
-    "fast-diff": {
-      "version": "1.2.0",
       "dev": true
     },
     "fast-glob": {
@@ -11651,13 +11603,6 @@
     "prettier": {
       "version": "2.6.2",
       "dev": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "eslint": "^8.17.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^4.0.0",
     "lint-staged": "^13.0.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2",


### PR DESCRIPTION
This follows the official guidance of the Prettier team ([from here](https://prettier.io/docs/en/integrating-with-linters.html#notes)):

> The downsides of those plugins are:
>
> 1. You end up with a lot of red squiggly lines in your editor, which gets annoying. Prettier is supposed to make you forget about formatting – and not be in your face about it!
> 2. They are slower than running Prettier directly.
> 3. They’re yet one layer of indirection where things may break.

---

**tldr;** in practice, folks are unlikely to notice this change (other than that they won't have so many "annoying red squiggles").

After this change:

* `eslint` will not flag prettier errors
* Most editors will continue to use prettier on save (this is a very common setup for folks using VSCode / NeoVim / etc)
* CI will still ensure that `prettier --check .` passes across the whole repo
* The recommended `lint-staged` setup (and the `CONTRIBUTING.md` info) will continue to work really well for folks
