### PR TITLE
bug: adds prepublish to make sure published packages have dist and d.ts file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,39 @@
-
 ## v0.1.0 (2022-08-01)
 
 #### :rocket: Enhancement
-* `network`
-  * [#12](https://github.com/data-eden/data-eden/pull/12) feat: adds buildFetch functionality to network ([@gabrielcsapo](https://github.com/gabrielcsapo))
+
+- `network`
+  - [#12](https://github.com/data-eden/data-eden/pull/12) feat: adds buildFetch functionality to network ([@gabrielcsapo](https://github.com/gabrielcsapo))
 
 #### :memo: Documentation
-* `network`
-  * [#29](https://github.com/data-eden/data-eden/pull/29) hjdivad/middlewares with header api ([@hjdivad](https://github.com/hjdivad))
-  * [#7](https://github.com/data-eden/data-eden/pull/7) ReadMe Driven Development ([@hjdivad](https://github.com/hjdivad))
-* Other
-  * [#23](https://github.com/data-eden/data-eden/pull/23) Setup basic CONTRIBUTING.md. ([@rwjblue](https://github.com/rwjblue))
-  * [#20](https://github.com/data-eden/data-eden/pull/20) feat: adds lint staged and contributing docs on how to install the git hook ([@gabrielcsapo](https://github.com/gabrielcsapo))
+
+- `network`
+  - [#29](https://github.com/data-eden/data-eden/pull/29) hjdivad/middlewares with header api ([@hjdivad](https://github.com/hjdivad))
+  - [#7](https://github.com/data-eden/data-eden/pull/7) ReadMe Driven Development ([@hjdivad](https://github.com/hjdivad))
+- Other
+  - [#23](https://github.com/data-eden/data-eden/pull/23) Setup basic CONTRIBUTING.md. ([@rwjblue](https://github.com/rwjblue))
+  - [#20](https://github.com/data-eden/data-eden/pull/20) feat: adds lint staged and contributing docs on how to install the git hook ([@gabrielcsapo](https://github.com/gabrielcsapo))
 
 #### :house: Internal
-* `athena`, `cache`, `network`
-  * [#25](https://github.com/data-eden/data-eden/pull/25) Add simple package.json linting setup ([@rwjblue](https://github.com/rwjblue))
-  * [#19](https://github.com/data-eden/data-eden/pull/19) Add eslint <-> TypeScript integration ([@rwjblue](https://github.com/rwjblue))
-  * [#18](https://github.com/data-eden/data-eden/pull/18) Add prettier setup to CI ([@rwjblue](https://github.com/rwjblue))
-  * [#14](https://github.com/data-eden/data-eden/pull/14) Add basic vitest test harness ([@rwjblue](https://github.com/rwjblue))
-  * [#10](https://github.com/data-eden/data-eden/pull/10) Only allow importing from the entry point of each package ([@rwjblue](https://github.com/rwjblue))
-  * [#9](https://github.com/data-eden/data-eden/pull/9) Add TypeScript build infrastructure ([@rwjblue](https://github.com/rwjblue))
-* Other
-  * [#23](https://github.com/data-eden/data-eden/pull/23) Setup basic CONTRIBUTING.md. ([@rwjblue](https://github.com/rwjblue))
-  * [#24](https://github.com/data-eden/data-eden/pull/24) Remove `prettier` integration from eslint setup. ([@rwjblue](https://github.com/rwjblue))
-  * [#22](https://github.com/data-eden/data-eden/pull/22) Add `npm run lint:fix` setup ([@rwjblue](https://github.com/rwjblue))
-  * [#20](https://github.com/data-eden/data-eden/pull/20) feat: adds lint staged and contributing docs on how to install the git hook ([@gabrielcsapo](https://github.com/gabrielcsapo))
-  * [#17](https://github.com/data-eden/data-eden/pull/17) Ensure we ignore /packages/*/dist when linting ([@rwjblue](https://github.com/rwjblue))
+
+- `athena`, `cache`, `network`
+  - [#25](https://github.com/data-eden/data-eden/pull/25) Add simple package.json linting setup ([@rwjblue](https://github.com/rwjblue))
+  - [#19](https://github.com/data-eden/data-eden/pull/19) Add eslint <-> TypeScript integration ([@rwjblue](https://github.com/rwjblue))
+  - [#18](https://github.com/data-eden/data-eden/pull/18) Add prettier setup to CI ([@rwjblue](https://github.com/rwjblue))
+  - [#14](https://github.com/data-eden/data-eden/pull/14) Add basic vitest test harness ([@rwjblue](https://github.com/rwjblue))
+  - [#10](https://github.com/data-eden/data-eden/pull/10) Only allow importing from the entry point of each package ([@rwjblue](https://github.com/rwjblue))
+  - [#9](https://github.com/data-eden/data-eden/pull/9) Add TypeScript build infrastructure ([@rwjblue](https://github.com/rwjblue))
+- Other
+  - [#23](https://github.com/data-eden/data-eden/pull/23) Setup basic CONTRIBUTING.md. ([@rwjblue](https://github.com/rwjblue))
+  - [#24](https://github.com/data-eden/data-eden/pull/24) Remove `prettier` integration from eslint setup. ([@rwjblue](https://github.com/rwjblue))
+  - [#22](https://github.com/data-eden/data-eden/pull/22) Add `npm run lint:fix` setup ([@rwjblue](https://github.com/rwjblue))
+  - [#20](https://github.com/data-eden/data-eden/pull/20) feat: adds lint staged and contributing docs on how to install the git hook ([@gabrielcsapo](https://github.com/gabrielcsapo))
+  - [#17](https://github.com/data-eden/data-eden/pull/17) Ensure we ignore /packages/\*/dist when linting ([@rwjblue](https://github.com/rwjblue))
 
 #### Committers: 3
+
 - David J. Hamilton ([@hjdivad](https://github.com/hjdivad))
 - Gabriel Csapo ([@gabrielcsapo](https://github.com/gabrielcsapo))
 - Robert Jackson ([@rwjblue](https://github.com/rwjblue))
-
 
 # Changelog

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "tsc --build",
     "build:watch": "tsc --watch",
+    "prepublish": "npm run build",
     "test": "npm-run-all lint test:*",
     "test:workspaces": "npm test --workspaces",
     "lint": "npm-run-all \"lint:!(fix)\"",
@@ -68,6 +69,9 @@
         "launchEditor": true
       },
       "release-it-yarn-workspaces": true
+    },
+    "hooks": {
+      "before:init": "npm run build"
     },
     "git": {
       "tagName": "v${version}"


### PR DESCRIPTION
# Summary

The published output does not contain the dist directory

<img width="429" alt="Screen Shot 2022-08-03 at 1 39 33 PM" src="https://user-images.githubusercontent.com/1854811/182709857-4b232869-9c5c-450c-b60a-c239bd0a3a5f.png">

I utilized the release-it hooks before the npm hooks are not being triggered via release-it

<img width="1102" alt="Screen Shot 2022-08-03 at 1 53 23 PM" src="https://user-images.githubusercontent.com/1854811/182709966-68d31cd8-079c-40ce-b64c-a55963c495f2.png">


