### PR TITLE
Add `CHANGELOG.md` to `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
+/CHANGELOG.md
 /packages/*/dist
 /packages/*/node_modules


### PR DESCRIPTION
The `CHANGELOG.md` is auto-generated (by `lerna-changelog`), and at the moment it emits content that doesn't pass `prettier --check`.

This change instructs `prettier` to ignore `CHANGELOG.md`, so that releasing doesn't cause subsequent CI failures.
