### PR TITLE
feat: export types from fetch to utilize in external middlewares

### DIFF
--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,1 +1,3 @@
 export { buildFetch } from './fetch';
+
+export type { Middleware, NormalizedFetch } from './fetch';


### PR DESCRIPTION
# Summary

I am working on an external middleware and can't import the types necessary.

<img width="794" alt="Screen Shot 2022-08-04 at 10 46 11 AM" src="https://user-images.githubusercontent.com/1854811/182917390-339f1cfb-78bb-46a2-9c08-056906da9997.png">
