### PR TITLE
chore: makes changes to be able to consume as an esm package

### DIFF
--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,3 +1,3 @@
-export { buildFetch } from './fetch';
+export { buildFetch } from './fetch.js';
 
-export type { Middleware, NormalizedFetch } from './fetch';
+export type { Middleware, NormalizedFetch } from './fetch.js';

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -4,10 +4,10 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "module": "node16",
+    "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es2020",
+    "target": "es6",
     "baseUrl": ".",
     "paths": {
       "*": ["./types/*"]


### PR DESCRIPTION
# Summary

Without these changes, the package is failed to be seen as an esm package natively.

<img width="1184" alt="Screen Shot 2022-08-04 at 3 52 19 PM" src="https://user-images.githubusercontent.com/1854811/182968312-131cefd1-212b-417d-82fe-69fcc905cab8.png">
