### PR TITLE
feat: have a default export to handle webpack use case

### DIFF
--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -13,7 +13,8 @@
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      }
+      },
+      "default": "./dist/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
# Summary

https://webpack.js.org/guides/package-exports/#common-patterns expects a default when it doesn't understand the sub fields for a given expression. When bringing this into a project it failed unless this was added.