### PR TITLE
Add `main` and `typings` to packages

### DIFF
--- a/packages/athena/package.json
+++ b/packages/athena/package.json
@@ -16,6 +16,8 @@
       }
     }
   },
+  "main": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
   "scripts": {
     "test": "vitest run"
   },

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -16,6 +16,8 @@
       }
     }
   },
+  "main": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
   "scripts": {
     "test": "vitest run"
   },

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -17,6 +17,8 @@
       "default": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
   "scripts": {
     "test": "vitest run"
   },


### PR DESCRIPTION
When TypeScript consumers are using `moduleResolution: 'node'` (which is the only real value that folks using older TypeScript or Node versions could have used) the `exports` property is never used / accessed. Adding `main`/`typings` enables consumers using `moduleResolution: 'node'` to work without requiring a TypeScript bump, or themselves to migrate to `node16`.
