### PR TITLE
Create `settled-tracking-middleware`

### DIFF
--- a/packages/network/__tests__/settled-tracking-middleware-test.ts
+++ b/packages/network/__tests__/settled-tracking-middleware-test.ts
@@ -1,0 +1,404 @@
+import {
+  beforeAll,
+  beforeEach,
+  afterAll,
+  afterEach,
+  expect,
+  test,
+  describe,
+} from 'vitest';
+
+import {
+  buildFetch,
+  SettledTrackingMiddleware,
+  hasPendingRequests,
+  requestsCompleted,
+  getPendingRequestState,
+  FetchDebugInfo,
+} from '@data-eden/network';
+
+// TODO: this should actually be import { _setupDefaultRequestsCompletedOptions } from '#settled-tracking-middleware'
+//   but we need https://github.com/vitejs/vite/pull/7770 to land in order to leverage subpath imports properly
+import { _setupDefaultRequestsCompletedOptions } from '@data-eden/network/-private/settled-tracking-middleware';
+
+import * as http from 'http';
+
+import { fileURLToPath } from 'url';
+import * as path from 'path';
+
+import { createServer } from '@data-eden/shared-test-utilities';
+
+describe('@data-eden/network: settled-tracking-middleware', async function () {
+  const server = await createServer();
+
+  function sanitizeStacktrace(errorStack: string): string {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const prefix = path.resolve(__dirname, '../../../');
+    const lines = errorStack.split('\n');
+
+    return (
+      lines
+        // only look at the first 3 stack frames to avoid including a bunch of node_modules and whatnot
+        .slice(0, 3)
+        // strip the repo root prefix from the stacks to ensure stable across users
+        .map((line: string) => line.replace(prefix, ''))
+        // strip line:col information
+        .map((line: string) => line.replace(/:\d+:\d+/, ''))
+        // remove trailing whitespace (avoids snapshot instability for editors that auto delete trailing whitespace)
+        .map((line: string) => line.trimEnd())
+        .join('\n')
+    );
+  }
+
+  function sanitizeServerUrl(input: string): string {
+    const baseUrl = server.buildUrl('');
+
+    return input.replace(baseUrl, '');
+  }
+
+  function simplifyPendingState(pendingState: FetchDebugInfo[]) {
+    return pendingState.map((debugInfo) => {
+      const prefixLength = server.buildUrl('').length;
+
+      if (debugInfo.stack === undefined) {
+        throw new Error('stack trace not found');
+      }
+
+      return {
+        ...debugInfo,
+        startTime: 99999999,
+        stack: sanitizeStacktrace(debugInfo.stack),
+        url: debugInfo.url.slice(prefixLength),
+      };
+    });
+  }
+
+  beforeAll(() => server.listen());
+  beforeEach(() => {
+    server.get(
+      '/resource',
+      (_request: http.IncomingMessage, response: http.ServerResponse) => {
+        response.writeHead(200, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({ status: 'success' }));
+      }
+    );
+  });
+  afterEach(() => server.reset());
+  afterAll(() => server.close());
+
+  test('hasPendingRequest returns true for multiple requests', async () => {
+    const fetch = buildFetch([SettledTrackingMiddleware]);
+
+    expect(hasPendingRequests(fetch)).toEqual(false);
+
+    const fetch1 = fetch(server.buildUrl('/resource'));
+    const fetch2 = fetch(server.buildUrl('/resource'));
+
+    expect(hasPendingRequests(fetch)).toEqual(true);
+
+    await fetch1;
+
+    expect(hasPendingRequests(fetch)).toEqual(true);
+
+    await fetch2;
+
+    expect(hasPendingRequests(fetch)).toEqual(false);
+  });
+
+  test('hasPendingRequest returns true when requests are outstanding with multiple `buildFetch` calls', async () => {
+    const fetch1 = buildFetch([SettledTrackingMiddleware]);
+    const fetch2 = buildFetch([SettledTrackingMiddleware]);
+
+    expect(
+      hasPendingRequests(fetch1),
+      'middleware1 no requests started'
+    ).toEqual(false);
+    expect(
+      hasPendingRequests(fetch2),
+      'middleware2 no request started'
+    ).toEqual(false);
+
+    const fetchResult1 = fetch1(server.buildUrl('/resource'));
+
+    expect(
+      hasPendingRequests(fetch1),
+      'middleware1 when request initiated'
+    ).toEqual(true);
+    expect(
+      hasPendingRequests(fetch2),
+      'middleware2 no requests started (after middleware1 started)'
+    ).toEqual(false);
+
+    const fetchResult2 = fetch2(server.buildUrl('/resource'));
+
+    expect(
+      hasPendingRequests(fetch1),
+      'middleware1 when request initiated for both'
+    ).toEqual(true);
+    expect(
+      hasPendingRequests(fetch2),
+      'middleware2 when request initiated'
+    ).toEqual(true);
+
+    await fetchResult1;
+
+    expect(
+      hasPendingRequests(fetch1),
+      'middleware1 after request awaited'
+    ).toEqual(false);
+    expect(
+      hasPendingRequests(fetch2),
+      'middleware2 after middleware1 request awaited'
+    ).toEqual(true);
+
+    await fetchResult2;
+
+    expect(
+      hasPendingRequests(fetch1),
+      'middleware1 after all requests completed'
+    ).toEqual(false);
+    expect(
+      hasPendingRequests(fetch2),
+      'middleware2 after all requests completed'
+    ).toEqual(false);
+  });
+
+  test('getPendingRequestState returns an empty array when no requests have been done', async () => {
+    const fetch = buildFetch([SettledTrackingMiddleware]);
+
+    expect(
+      simplifyPendingState(getPendingRequestState(fetch))
+    ).toMatchInlineSnapshot('[]');
+  });
+
+  test('getPendingRequestState includes debug information for all currently pending requests', async () => {
+    const fetch1 = buildFetch([SettledTrackingMiddleware]);
+    const fetch2 = buildFetch([SettledTrackingMiddleware]);
+
+    const fetches = [
+      fetch1(server.buildUrl('/resource')),
+      fetch2(server.buildUrl('/resource')),
+      fetch1(server.buildUrl('/resource')),
+      fetch2(server.buildUrl('/resource')),
+    ];
+
+    try {
+      expect(simplifyPendingState(getPendingRequestState(fetch1)))
+        .toMatchInlineSnapshot(`
+          [
+            {
+              "method": "GET",
+              "stack": "Error:
+              at SettledTrackingMiddleware (file:///packages/network/src/settled-tracking-middleware.ts)
+              at file:///packages/network/src/fetch.ts",
+              "startTime": 99999999,
+              "url": "/resource",
+            },
+            {
+              "method": "GET",
+              "stack": "Error:
+              at SettledTrackingMiddleware (file:///packages/network/src/settled-tracking-middleware.ts)
+              at file:///packages/network/src/fetch.ts",
+              "startTime": 99999999,
+              "url": "/resource",
+            },
+          ]
+        `);
+
+      expect(simplifyPendingState(getPendingRequestState(fetch2)))
+        .toMatchInlineSnapshot(`
+          [
+            {
+              "method": "GET",
+              "stack": "Error:
+              at SettledTrackingMiddleware (file:///packages/network/src/settled-tracking-middleware.ts)
+              at file:///packages/network/src/fetch.ts",
+              "startTime": 99999999,
+              "url": "/resource",
+            },
+            {
+              "method": "GET",
+              "stack": "Error:
+              at SettledTrackingMiddleware (file:///packages/network/src/settled-tracking-middleware.ts)
+              at file:///packages/network/src/fetch.ts",
+              "startTime": 99999999,
+              "url": "/resource",
+            },
+          ]
+        `);
+    } finally {
+      await Promise.allSettled(fetches);
+    }
+  });
+
+  test('requestCompleted waits for all pending requests', async () => {
+    const fetch = buildFetch([SettledTrackingMiddleware]);
+
+    const steps: string[] = [];
+    steps.push(`hasPendingRequests: ${String(hasPendingRequests(fetch))}`);
+
+    const fetch1 = fetch(server.buildUrl('/resource'));
+    const fetch2 = fetch(server.buildUrl('/resource'));
+
+    const completedPromise = requestsCompleted(fetch).then(() => {
+      steps.push('requests completed');
+    });
+
+    steps.push(`hasPendingRequests: ${String(hasPendingRequests(fetch))}`);
+
+    await fetch1;
+
+    steps.push(`hasPendingRequests: ${String(hasPendingRequests(fetch))}`);
+
+    await fetch2;
+
+    steps.push(`hasPendingRequests: ${String(hasPendingRequests(fetch))}`);
+
+    await completedPromise;
+
+    expect(steps).toMatchInlineSnapshot(`
+      [
+        "hasPendingRequests: false",
+        "hasPendingRequests: true",
+        "hasPendingRequests: true",
+        "requests completed",
+        "hasPendingRequests: false",
+      ]
+    `);
+  });
+
+  test('requestCompleted resolves when no requests have been made', async () => {
+    const fetch = buildFetch([SettledTrackingMiddleware]);
+
+    await requestsCompleted(fetch);
+  });
+
+  test('requestsCompleted with a custom timeout', async () => {
+    expect.assertions(3);
+
+    const steps: string[] = [];
+    const fetch = buildFetch([SettledTrackingMiddleware]);
+
+    server.get(
+      '/slow-request',
+      (_request: http.IncomingMessage, response: http.ServerResponse) => {
+        setTimeout(() => {
+          steps.push('/slow-response resolving');
+          response.writeHead(200, { 'Content-Type': 'application/json' });
+          response.end(JSON.stringify({ status: 'success' }));
+        }, 50);
+      }
+    );
+
+    let fetchPromise;
+
+    try {
+      fetchPromise = fetch(server.buildUrl('/slow-request'));
+
+      await requestsCompleted(fetch, { timeout: 5 });
+      steps.push('requestCompleted resolved incorrectly');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        expect(sanitizeServerUrl(error.message)).toMatchInlineSnapshot(`
+          "requestsCompleted timeout waiting for requests to complete:
+            GET /slow-request"
+        `);
+        expect(error.name).toMatchInlineSnapshot(
+          '"SETTLED_MIDDLEDWARE_REQUEST_COMPLETED_TIMEOUT"'
+        );
+      }
+    } finally {
+      await fetchPromise;
+    }
+
+    try {
+      fetchPromise = fetch(server.buildUrl('/slow-request'));
+
+      await requestsCompleted(fetch, { timeout: 100 });
+
+      expect(steps).toMatchInlineSnapshot(`
+        [
+          "/slow-response resolving",
+          "/slow-response resolving",
+        ]
+      `);
+    } finally {
+      await fetchPromise;
+    }
+  });
+
+  test('requestsCompleted with a custom timeout message prefix', async () => {
+    expect.assertions(1);
+
+    const steps: string[] = [];
+    const fetch = buildFetch([SettledTrackingMiddleware]);
+
+    server.get(
+      '/slow-request',
+      (_request: http.IncomingMessage, response: http.ServerResponse) => {
+        setTimeout(() => {
+          steps.push('/slow-response resolving');
+          response.writeHead(200, { 'Content-Type': 'application/json' });
+          response.end(JSON.stringify({ status: 'success' }));
+        }, 50);
+      }
+    );
+
+    let fetchPromise;
+
+    try {
+      fetchPromise = fetch(server.buildUrl('/slow-request'));
+
+      await requestsCompleted(fetch, {
+        timeout: 5,
+        timeoutMessagePrefix: 'HIYA',
+      });
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        expect(sanitizeServerUrl(error.message)).toMatchInlineSnapshot(`
+          "HIYA
+            GET /slow-request"
+        `);
+      }
+    } finally {
+      await fetchPromise;
+    }
+  });
+
+  test('requestsCompleted when requests take longer than default timeout', async () => {
+    expect.assertions(1);
+
+    const steps: string[] = [];
+    const fetch = buildFetch([SettledTrackingMiddleware]);
+
+    server.get(
+      '/slow-request',
+      (_request: http.IncomingMessage, response: http.ServerResponse) => {
+        setTimeout(() => {
+          steps.push('/slow-response resolving');
+          response.writeHead(200, { 'Content-Type': 'application/json' });
+          response.end(JSON.stringify({ status: 'success' }));
+        }, 50);
+      }
+    );
+
+    let fetchPromise;
+
+    try {
+      fetchPromise = fetch(server.buildUrl('/slow-request'));
+
+      _setupDefaultRequestsCompletedOptions({ timeout: 5 });
+
+      await requestsCompleted(fetch);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        expect(sanitizeServerUrl(error.message)).toMatchInlineSnapshot(`
+          "requestsCompleted timeout waiting for requests to complete:
+            GET /slow-request"
+        `);
+      }
+    } finally {
+      await fetchPromise;
+    }
+  });
+});

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -8,6 +8,9 @@
   },
   "license": "MIT",
   "type": "module",
+  "imports": {
+    "#settled-tracking-middleware": "./src/settled-tracking-middleware.ts"
+  },
   "exports": {
     ".": {
       "import": {
@@ -15,7 +18,9 @@
         "default": "./dist/index.js"
       },
       "default": "./dist/index.js"
-    }
+    },
+    "./NOTE01": "This should be removed once https://github.com/vitejs/vite/pull/7770 lands, and we can use `imports` properly",
+    "./-private/settled-tracking-middleware": "./dist/settled-tracking-middleware.js"
   },
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,4 +1,15 @@
 export { buildFetch } from './fetch.js';
+export {
+  hasPendingRequests,
+  getPendingRequestState,
+  default as SettledTrackingMiddleware,
+  requestsCompleted,
+} from './settled-tracking-middleware.js';
+
+export type {
+  FetchDebugInfo,
+  RequestsCompletedOptions,
+} from './settled-tracking-middleware.js';
 
 export type {
   Middleware,

--- a/packages/network/src/settled-tracking-middleware.ts
+++ b/packages/network/src/settled-tracking-middleware.ts
@@ -1,0 +1,256 @@
+import type { Fetch, MiddlewareMetadata, NormalizedFetch } from './fetch.js';
+
+/**
+  Debug information that is exposed via `getPendingRequestState(...)`.
+
+  This is intended to provide enough information to be used to debug tests
+  where requests are not completing as expected.
+*/
+export interface FetchDebugInfo {
+  stack?: string;
+  startTime: number;
+  method: string;
+  url: string;
+}
+
+const TrackingInfoPerFetch: WeakMap<Fetch, FetchDebugInfo[]> = new WeakMap();
+const RequestsCompletedPromisesByToken: WeakMap<Fetch, InternalDeferred> =
+  new WeakMap();
+
+/**
+  Exposes a mechanism that can be used to know if all requests that have
+  been started with a given `buildFetch` result have completed.
+
+  @example
+
+  ```js
+  import { hasPendingRequests } from '@data-eden/network';
+  import { fetch } from './my-app-buildFetch';
+
+  console.log(hasPendingRequests(fetch)) // => false;
+
+  let result = fetch('/some-url');
+
+  console.log(hasPendingRequests(fetch)) // => true;
+
+  await result;
+
+  console.log(hasPendingRequests(fetch)) // => false;
+  ```
+*/
+export function hasPendingRequests(originatingFetch: Fetch): boolean {
+  return getPendingRequestState(originatingFetch).length > 0;
+}
+
+/**
+  Get an array of the currently pending requests for a given `fetch` function
+  (e.g. `buildFetch` result).
+
+  @example
+
+  ```js
+  import { getPendingRequestState } from '@data-eden/network';
+  import { fetch } from './my-app-buildFetch';
+
+  console.log(getPendingRequestState(fetch)) // => [];
+
+  let result = fetch('/some-url');
+
+  console.log(hasPendingRequests(fetch)) // =>
+          [
+            {
+              "method": "GET",
+              "stack": "Error:
+              at SettledTrackingMiddleware (file:///packages/network/src/settled-tracking-middleware.ts)
+              at file:///packages/network/src/fetch.ts",
+              "startTime": 1675198640993,
+              "url": "/some-url",
+            },
+          ]
+
+  await result;
+
+  console.log(getPendingRequestState(fetch)) // => [];
+  ```
+*/
+export function getPendingRequestState(
+  originatingFetch: Fetch
+): FetchDebugInfo[] {
+  const fetchDebugInfos = TrackingInfoPerFetch.get(originatingFetch);
+
+  if (fetchDebugInfos === undefined) {
+    return [];
+  }
+
+  return fetchDebugInfos;
+}
+
+export interface RequestsCompletedOptions {
+  timeout?: number;
+  timeoutMessagePrefix?: string;
+}
+
+export let defaultRequestsCompletedOptions: RequestsCompletedOptions;
+
+export function _setupDefaultRequestsCompletedOptions(
+  options?: RequestsCompletedOptions
+) {
+  defaultRequestsCompletedOptions = {
+    timeout: 2_000,
+    timeoutMessagePrefix:
+      'requestsCompleted timeout waiting for requests to complete:',
+    ...options,
+  };
+}
+_setupDefaultRequestsCompletedOptions();
+
+/**
+  Exposes a mechanism to wait for all currently pending requests to
+  be completed. This is useful in some testing contexts. For example,
+  to know when any fetch related async is completed so that you can
+  run various assertions on the results.
+
+  @example
+
+  ```js
+  import { requestsCompleted } from '@data-eden/network';
+  import { fetch } from './my-app-buildFetch';
+
+  test('updates data when submitted', async function() {
+    await render(...);
+
+    await click('[some-button]');
+
+    await requestsCompleted(fetch);
+
+    expect(document.querySelector('.some-content').textContent).toMatchSnapshot();
+  });
+  ```
+*/
+export async function requestsCompleted(
+  originatingFetch: Fetch,
+  _options: RequestsCompletedOptions = {}
+): Promise<unknown> {
+  const options = { ...defaultRequestsCompletedOptions, ..._options };
+  const deferred = RequestsCompletedPromisesByToken.get(originatingFetch);
+
+  if (deferred) {
+    let error = new Error(options.timeoutMessagePrefix);
+    error.name = 'SETTLED_MIDDLEDWARE_REQUEST_COMPLETED_TIMEOUT';
+
+    const timeout = new Promise((_resolve, reject) => {
+      setTimeout(() => {
+        let pendingRequests = getPendingRequestState(originatingFetch)
+          .map(({ method, url }) => `  ${method} ${url}`)
+          .join('\n');
+
+        error.message += `\n${pendingRequests}`;
+        reject(error);
+      }, options.timeout);
+    });
+
+    return Promise.race([deferred.promise, timeout]);
+  }
+}
+
+interface InternalDeferred {
+  promise: Promise<unknown>;
+  resolve: (value: void) => void;
+}
+
+function defer(): InternalDeferred {
+  let resolve!: (value: unknown) => void;
+  const promise = new Promise((_resolve) => {
+    resolve = _resolve;
+  });
+
+  return {
+    promise,
+    resolve,
+  };
+}
+
+/**
+  The primary goal of this middleware is to expose a mechanism for
+  consumers to know when all requests are completed. This is **very**
+  useful for testing purposes where you may want to author tests in a
+  higher level way (e.g. "click this button and confirm some content
+  is updated").
+
+  Note: This middleware is intended to be used in non-production contexts
+    (e.g. when debugging or running tests).
+
+  @example
+  ```js
+  import { fetch } from '../network';
+  import { requestsCompleted } from '@data-eden/network';
+
+  test('updates data when submitted', async function() {
+    await render(...);
+
+    await click('[some-button]');
+
+    await requestsCompleted(fetch);
+
+    expect(document.querySelector('.some-content').textContent).toMatchSnapshot();
+  });
+  ```
+*/
+export default async function SettledTrackingMiddleware(
+  request: Request,
+  next: NormalizedFetch,
+  metadata: MiddlewareMetadata
+) {
+  const error = new Error();
+
+  const originatingFetch = metadata.fetch;
+
+  let fetchDebugInfos = TrackingInfoPerFetch.get(originatingFetch);
+  if (fetchDebugInfos === undefined) {
+    fetchDebugInfos = [];
+    TrackingInfoPerFetch.set(originatingFetch, fetchDebugInfos);
+  }
+
+  if (fetchDebugInfos.length === 0) {
+    const deferred = defer();
+    RequestsCompletedPromisesByToken.set(originatingFetch, deferred);
+  }
+
+  const debugInfo: FetchDebugInfo = {
+    url: request.url,
+    method: request.method,
+    startTime: Date.now(),
+    get stack() {
+      return error.stack;
+    },
+  };
+
+  fetchDebugInfos.push(debugInfo);
+
+  try {
+    return await next(request);
+  } finally {
+    const index = fetchDebugInfos.findIndex((item) => item === debugInfo);
+
+    if (index === -1) {
+      // eslint-disable-next-line no-unsafe-finally
+      throw new Error(
+        '[INTERNAL ERROR @data-eden/network]: Could not find debug information for a previously started request'
+      );
+    }
+    fetchDebugInfos.splice(index, 1);
+
+    if (fetchDebugInfos.length === 0) {
+      const deferred = RequestsCompletedPromisesByToken.get(originatingFetch);
+
+      if (deferred === undefined) {
+        // eslint-disable-next-line no-unsafe-finally
+        throw new Error(
+          '[INTERNAL ERROR @data-eden/network]: Could not find requestsCompleted promise for a previously started request'
+        );
+      }
+
+      deferred.resolve();
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces a new built-in middleware that consumers can use in non-production contexts (e.g. when debugging or running tests).

The primary goal is to expose a mechanism for consumers to know when all requests are completed. This is **very** useful for testing purposes where you may want to author tests in a higher level way (e.g. "click this button and confirm some content is updated").

```js
import { fetch } from '../network';
import { requestsCompleted } from '@data-eden/network';

test('updates data when submitted', async function() {
  await render(...);

  await click('[some-button]');

  await requestsCompleted(fetch);

  expect(document.querySelector('.some-content').textContent).toMatchSnapshot();
});
```