### PR TITLE
Improve test performance: Don't wait on `server.close()`

### DIFF
--- a/internal-packages/shared-test-utilities/src/server.ts
+++ b/internal-packages/shared-test-utilities/src/server.ts
@@ -64,15 +64,7 @@ export async function createServer(): Promise<Server> {
     },
 
     async close() {
-      return new Promise((resolve, reject) => {
-        server.close((error?: Error) => {
-          if (error !== undefined) {
-            reject(error);
-          } else {
-            resolve();
-          }
-        });
-      });
+      server.close();
     },
 
     get(path: string, handler: RequestHandler) {


### PR DESCRIPTION
We don't _need_ to wait for the server to be closed in order to continue execution (many examples in Node's own documentation run `server.close(); server.listen(host, port)` back to back).

This removes a ~ 4 second delay in `@data-eden/network`'s test suite (during `afterAll` where we call `await server.close()`).
