### PR TITLE
Use `dist/` for exports in @data-eden/cache

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -12,9 +12,10 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./src/index.ts",
-        "default": "./src/index.ts"
-      }
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "default": "./dist/index.js"
     }
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
For published assets, we **must** use `dist/` in our `exports`.

We ultimately want to use `src/` locally and change this to `dist/` upon publish, but at the moment things are fundamentally broken for WebPack consumers so this is a "quick fix" for the published consumer.

A follow-on PR should fix all of our workspaces to use `src/` checked in, and update to `dist/` locations for `npm publish`.