### PR TITLE
Ensure changelog can be edited before publishing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "plugins": {
       "@release-it-plugins/lerna-changelog": {
         "infile": "CHANGELOG.md",
-        "launchEditor": false
+        "launchEditor": true
       },
       "@release-it-plugins/workspaces": true
     },


### PR DESCRIPTION
Rolls back a change made in 668282adaef6383777f584e4f49ca5e140286014 (and pushed directly to `main`).

/cc @gabrielcsapo
