### PR TITLE
Run `npm install` after the versions are bumped

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "registry": "https://registry.npmjs.org"
   },
   "release-it": {
+    "scripts": {
+      "after:bump": "npm install"
+    },
     "plugins": {
       "@release-it-plugins/lerna-changelog": {
         "infile": "CHANGELOG.md",


### PR DESCRIPTION
This helps ensure that `package-lock.json` is kept in sync (with the current setup, `@release-it-plugins/workspaces` **does _not_** ensure that `package-lock.json` is up to date).

References https://github.com/release-it-plugins/workspaces/issues/85
