### PR TITLE
Ensure that `fetch` is only accessed lazily (allow mocking)

### DIFF
--- a/packages/network/__tests__/fetch-test.ts
+++ b/packages/network/__tests__/fetch-test.ts
@@ -164,6 +164,54 @@ describe('@data-eden/fetch', async function () {
     `);
   });
 
+  test('allows globalThis.fetch to be mocked per test (e.g. Pretender / MirageJS / msw style)', async () => {
+    const fetch = buildFetch([]);
+
+    let response = await fetch(server.buildUrl('/resource'));
+
+    expect(await response.json(), 'precond - uses globalThis.fetch by default')
+      .toMatchInlineSnapshot(`
+      {
+        "customOriginalRequestHeaders": {},
+        "status": "success",
+      }
+    `);
+
+    const originalFetch = globalThis.fetch;
+
+    try {
+      /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any*/
+      delete (globalThis as any).fetch;
+
+      const customFetch = (
+        _input: URL | RequestInfo,
+        _init?: RequestInit
+      ): Promise<Response> => {
+        // does not call `next` at all, just resolves with some specific response
+        return Promise.resolve(new Response('We overrode fetch!'));
+      };
+
+      // overrides the global `fetch` **after** `buildFetch` has been called
+      globalThis.fetch = customFetch;
+
+      response = await fetch(server.buildUrl('/resource'));
+
+      expect(
+        await response.text(),
+        'overriden fetch was used'
+      ).toMatchInlineSnapshot('"We overrode fetch!"');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    response = await fetch(server.buildUrl('/resource'));
+
+    expect(
+      response.status,
+      'original fetch was used after globalThis.fetch was reset'
+    ).toEqual(200);
+  });
+
   test('should be able to override fetch', async () => {
     expect.assertions(1);
 
@@ -181,6 +229,34 @@ describe('@data-eden/fetch', async function () {
     const response = await fetch('https://www.example.com');
 
     expect(await response.text()).toMatchInlineSnapshot('"We overrode fetch!"');
+  });
+
+  test('can not change options.fetch lazily', async () => {
+    const options = {
+      fetch: (
+        _input: URL | RequestInfo,
+        _init?: RequestInit
+      ): Promise<Response> => {
+        return Promise.resolve(new Response('custom fetch here!'));
+      },
+    };
+    const fetch = buildFetch([noopMiddleware], options);
+
+    let response = await fetch(server.buildUrl('/resource'));
+    expect(await response.text()).toMatchInlineSnapshot('"custom fetch here!"');
+
+    options.fetch = (
+      _input: URL | RequestInfo,
+      _init?: RequestInit
+    ): Promise<Response> => {
+      return Promise.resolve(new Response('We overrode fetch!'));
+    };
+
+    response = await fetch(server.buildUrl('/resource'));
+    expect(
+      await response.text(),
+      'overridden `options.fetch` is not used'
+    ).toMatchInlineSnapshot('"custom fetch here!"');
   });
 
   test('should be able to change the http method for a given request', async () => {

--- a/packages/network/src/fetch.ts
+++ b/packages/network/src/fetch.ts
@@ -41,6 +41,10 @@ function combine(
   };
 }
 
+function globalFetch(request: Request): Promise<Response> {
+  return fetch(request);
+}
+
 /**
  *
  * @param middlewares {Middleware[]} array of middlewares
@@ -56,8 +60,7 @@ export function buildFetch(
       "@data-eden/network requires `fetch` to be available on`globalThis`. Did you forget to setup `cross-fetch/polyfill` before calling @data-eden/network's `buildFetch`?"
     );
   }
-
-  const _fetch: NormalizedFetch = options?.fetch || fetch;
+  const _fetch: NormalizedFetch = options?.fetch || globalFetch;
 
   const curriedMiddlewares: NormalizedFetch = [...middlewares]
     .reverse()


### PR DESCRIPTION
Currently, it is not possible to mock `fetch` **after** `buildFetch` is invoked. This might _seem_ fine, but ultimately it is not:

- Generally speaking we expect `buildFetch` to be done **very** early in the application's evaluation. Specifically, this will be **_well_** before any individual tests are kicked off / ran.
- Tools like `Pretender` / `MirageJS` / `msw` need to be able to override `globalThis.fetch` lazily. Most of the time this is done within a specific test context (or after the tests have kicked off, in a `beforeEach`/`beforeAll` kinda of situation). Notably, these tests will almost certainly be directly `import { fetch } from 'app-name/network'` or something (which **guarantees** that the `buildFetch` will have been called already).

This commit ensures that `globalThis.fetch` is looked up lazily on `globalThis` each time it is needed (therefore allowing other tools to mock it as desired).

Note that we still eagerly error of `typeof fetch` is undefined when calling `buildFetch` as this helps folks absorb the breaking changes from 0.2 to 0.3 (no longer using cross-fetch internally).

---

Thanks to @cafreeman for pointing this out!