### PR TITLE
Ensure top level `build:watch` runs `tsc --build --watch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "tsc --build",
-    "build:watch": "tsc --watch",
+    "build:watch": "npm run build --- --watch",
     "prepublish": "npm run build",
     "postinstall": "patch-package",
     "test": "npm-run-all lint test:*",


### PR DESCRIPTION
Uses the `build` script, so any flag chagnes are shared
automatically.

Locally, without the `--build` flag I do not always get `dist/` created
in all of the workspaces.
