### PR TITLE
Add script to easily step through `buildFetch` usage.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,12 @@ module.exports = {
       extends: ['plugin:node/recommended'],
     },
     {
+      files: ['dev/**/*.[tj]s'],
+      env: {
+        node: true,
+      },
+    },
+    {
       files: ['**/*.ts'],
       parser: '@typescript-eslint/parser',
       parserOptions: {

--- a/dev/simple-fetch-script.js
+++ b/dev/simple-fetch-script.js
@@ -1,0 +1,40 @@
+import { createServer } from '@data-eden/shared-test-utilities';
+import { buildFetch } from '@data-eden/network';
+
+async function main() {
+  const server = await createServer();
+
+  server.get('/resource', (_request, response) => {
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.end(
+      JSON.stringify({
+        status: 'success',
+      })
+    );
+  });
+
+  await server.listen();
+
+  const url = server.buildUrl('/resource');
+
+  const noopMiddleware = async (request, next) => {
+    return next(request);
+  };
+
+  const csrfMiddleware = async (request, next) => {
+    request.headers.set('X-CSRF', 'a totally legit request');
+
+    return next(request);
+  };
+
+  const fetch = buildFetch([noopMiddleware, csrfMiddleware]);
+
+  const response = await fetch(url);
+  const result = await response.json();
+
+  console.log(`Result: ${result.status}`);
+
+  await server.close();
+}
+
+main();

--- a/internal-packages/shared-test-utilities/package.json
+++ b/internal-packages/shared-test-utilities/package.json
@@ -13,9 +13,9 @@
     ".": {
       "import": {
         "types": "./src/index.ts",
-        "default": "./src/index.js"
+        "default": "./dist/index.js"
       },
-      "default": "./src/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
Running `node --inspect-brk dev/simple-fetch-script.js` allows you to more easily step through `@data-eden/network`'s implementation.
