### PR TITLE
Expose metadata to middlewares

### DIFF
--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,3 +1,7 @@
 export { buildFetch } from './fetch.js';
 
-export type { Middleware, NormalizedFetch } from './fetch.js';
+export type {
+  Middleware,
+  MiddlewareMetadata,
+  NormalizedFetch,
+} from './fetch.js';


### PR DESCRIPTION
In some circumstances a middleware may need access to some metadata in order to perform its purpose. For example, a middleware that tracks requests/response (e.g. for tracking API failure rates) would want to ensure that it tracks those requests back to the original `buildFetch` (remember, there can _and will_ likely be many `buildFetch` calls within a large and complicated application) that ultimately triggered the requests to be fired.

In the future, this metadata will likely be expanded to include other information (e.g. `$debug` info). Those use cases can augment the infrastructure introduced here.
