### PR TITLE
Add test showing how to return a cached response

### DIFF
--- a/packages/network/__tests__/fetch-test.ts
+++ b/packages/network/__tests__/fetch-test.ts
@@ -473,6 +473,32 @@ describe('@data-eden/fetch', async function () {
     `);
   });
 
+  test('should be able to return cached data', async () => {
+    expect.assertions(2);
+
+    async function cachingMiddleware(
+      request: Request,
+      next: (request: Request) => Promise<Response>
+    ): Promise<Response> {
+      const response = new Response(
+        JSON.stringify({ status: 'cached-success' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+
+      return response;
+    }
+
+    const fetch = buildFetch([cachingMiddleware]);
+
+    const response = await fetch(server.buildUrl('/analytics'));
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toMatchInlineSnapshot(`
+      {
+        "status": "cached-success",
+      }
+    `);
+  });
+
   test('can read and mutate request headers', async function () {
     expect.assertions(2);
 


### PR DESCRIPTION
There is no requirement that a given middleware **must** call `next`, it is perfectly fine to directly return a response.

A common scenario for this might be to handle caching for a given request.

Closes #87 