### PR TITLE
chore: remove Fetch type export

### DIFF
--- a/packages/network/src/fetch.ts
+++ b/packages/network/src/fetch.ts
@@ -1,5 +1,3 @@
-export type Fetch = typeof fetch;
-
 export type NormalizedFetch = (request: Request) => Promise<Response>;
 
 export interface MiddlewareMetadata {
@@ -11,7 +9,7 @@ export interface MiddlewareMetadata {
     Note: The middleware **must not** actually invoke this `fetch` method (doing so
     will throw due to infinite recursion).
   */
-  fetch: Fetch;
+  fetch: typeof fetch;
 }
 
 export type Middleware = (
@@ -46,7 +44,7 @@ export interface BuildFetchOptions {
   /**
    * override the default fetch implementation
    */
-  fetch: Fetch;
+  fetch: typeof fetch;
 }
 
 function globalFetch(request: Request): Promise<Response> {
@@ -64,7 +62,7 @@ function globalFetch(request: Request): Promise<Response> {
 export function buildFetch(
   middlewares: Middleware[],
   options?: BuildFetchOptions
-): Fetch {
+): typeof fetch {
   if (typeof fetch === 'undefined') {
     throw new Error(
       "@data-eden/network requires `fetch` to be available on`globalThis`. Did you forget to setup `cross-fetch/polyfill` before calling @data-eden/network's `buildFetch`?"
@@ -72,7 +70,7 @@ export function buildFetch(
   }
   const _fetch: NormalizedFetch = options?.fetch || globalFetch;
 
-  let result: Fetch;
+  let result: typeof fetch;
 
   const curriedMiddlewares: NormalizedFetch = [...middlewares]
     .reverse()

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -16,5 +16,4 @@ export type {
   MiddlewareMetadata,
   NormalizedFetch,
   BuildFetchOptions,
-  Fetch,
 } from './fetch.js';

--- a/packages/network/src/settled-tracking-middleware.ts
+++ b/packages/network/src/settled-tracking-middleware.ts
@@ -1,4 +1,6 @@
-import type { Fetch, MiddlewareMetadata, NormalizedFetch } from './fetch.js';
+import type { MiddlewareMetadata, NormalizedFetch } from './fetch.js';
+
+type Fetch = typeof fetch;
 
 /**
   Debug information that is exposed via `getPendingRequestState(...)`.


### PR DESCRIPTION
We don't want to export a public custom `Fetch` type.  The mental model users should have is that `buildFetch()` returns a `typeof fetch` -- i.e. a fully fetch-compatible function.

The docs show `type Fetch = typeof fetch` as an example of something users might do to make their own code more readable, but it is not something that should be part of `@data-eden/network`'s public API.