### PR TITLE
enforce consistent type imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -43,6 +43,7 @@ module.exports = {
         'prefer-const': 'off',
         '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/require-await': 'off',
+        '@typescript-eslint/consistent-type-imports': 'error',
         '@typescript-eslint/no-unused-vars': [
           'error',
           {

--- a/internal-packages/react-graphql-test-app/src/@types/graphql.d.ts
+++ b/internal-packages/react-graphql-test-app/src/@types/graphql.d.ts
@@ -1,5 +1,5 @@
 declare module '*.graphql' {
-  import { DocumentNode } from 'graphql';
+  import type { DocumentNode } from 'graphql';
   const Schema: DocumentNode;
 
   export = Schema;

--- a/internal-packages/shared-test-utilities/__tests__/server.test.ts
+++ b/internal-packages/shared-test-utilities/__tests__/server.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe } from 'vitest';
-import * as http from 'http';
+import type * as http from 'http';
 
 import { createServer } from '@data-eden/shared-test-utilities';
 

--- a/packages/cache/__tests__/index-test.ts
+++ b/packages/cache/__tests__/index-test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 // TODO: add a tests tsconfig so we can import properly
-import { buildCache, DefaultRegistry } from '@data-eden/cache';
-import type { Cache } from '@data-eden/cache';
+import { buildCache } from '@data-eden/cache';
+import type { Cache, DefaultRegistry } from '@data-eden/cache';
 import { expectTypeOf } from 'vitest';
 
 // TODO: add tests for types

--- a/packages/network/__tests__/fetch-test.ts
+++ b/packages/network/__tests__/fetch-test.ts
@@ -7,14 +7,14 @@ import {
   test,
   describe,
 } from 'vitest';
-import * as http from 'http';
+import type * as http from 'http';
 
-import {
-  buildFetch,
+import type {
   Middleware,
   MiddlewareMetadata,
   NormalizedFetch,
 } from '@data-eden/network';
+import { buildFetch } from '@data-eden/network';
 import { createServer } from '@data-eden/shared-test-utilities';
 
 function getPrefixedIncomingHttpHeaders(

--- a/packages/network/__tests__/settled-tracking-middleware-test.ts
+++ b/packages/network/__tests__/settled-tracking-middleware-test.ts
@@ -8,20 +8,20 @@ import {
   describe,
 } from 'vitest';
 
+import type { FetchDebugInfo } from '@data-eden/network';
 import {
   buildFetch,
   SettledTrackingMiddleware,
   hasPendingRequests,
   requestsCompleted,
   getPendingRequestState,
-  FetchDebugInfo,
 } from '@data-eden/network';
 
 // TODO: this should actually be import { _setupDefaultRequestsCompletedOptions } from '#settled-tracking-middleware'
 //   but we need https://github.com/vitejs/vite/pull/7770 to land in order to leverage subpath imports properly
 import { _setupDefaultRequestsCompletedOptions } from '@data-eden/network/-private/settled-tracking-middleware';
 
-import * as http from 'http';
+import type * as http from 'http';
 
 import { fileURLToPath } from 'url';
 import * as path from 'path';


### PR DESCRIPTION
Turn on [@typescript-eslint/consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports/) and run `lint:fix`