### PR TITLE
feat: add --disable-schema-types-generation

### DIFF
--- a/packages/codegen/__tests__/codegen.test.ts
+++ b/packages/codegen/__tests__/codegen.test.ts
@@ -33,6 +33,7 @@ describe('codegen', () => {
       documents: [`${project.baseDir}/**/*.graphql`],
       baseDir: project.baseDir,
       extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
       production: false,
     });
 
@@ -95,6 +96,7 @@ describe('codegen', () => {
       documents: [`${project.baseDir}/**/*.graphql`],
       baseDir: project.baseDir,
       extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
       production: true,
     });
 
@@ -136,6 +138,7 @@ describe('codegen', () => {
       documents: [`${project.baseDir}/**/*.graphql`],
       baseDir: project.baseDir,
       extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
       production: false,
       hash(document) {
         let operationName = 'Document';
@@ -199,6 +202,7 @@ describe('codegen', () => {
       documents: [`${project.baseDir}/**/*.tsx`],
       baseDir: project.baseDir,
       extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
       production: false,
     });
 
@@ -233,6 +237,7 @@ describe('codegen', () => {
       documents: [`${project.baseDir}/**/*.tsx`],
       baseDir: project.baseDir,
       extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
       production: true,
     });
 
@@ -267,6 +272,7 @@ describe('codegen', () => {
       documents: [`${project.baseDir}/**/*.tsx`],
       baseDir: project.baseDir,
       extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
       production: false,
     });
 
@@ -285,6 +291,7 @@ describe('codegen', () => {
       documents: [`${project.baseDir}/**/*.tsx`],
       baseDir: project.baseDir,
       extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
       production: false,
     });
 
@@ -327,6 +334,7 @@ describe('codegen', () => {
       documents: [`${project.baseDir}/**/*.tsx`],
       baseDir: project.baseDir,
       extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
       production: false,
     });
 
@@ -396,6 +404,7 @@ describe('codegen', () => {
       documents: [`${project.baseDir}/**/*.tsx`],
       baseDir: project.baseDir,
       extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
       production: false,
     });
 
@@ -419,6 +428,7 @@ describe('codegen', () => {
       documents: [`${project.baseDir}/**/*.tsx`],
       baseDir: project.baseDir,
       extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
       production: false,
     });
 

--- a/packages/codegen/src/bin.ts
+++ b/packages/codegen/src/bin.ts
@@ -5,6 +5,7 @@ interface Options {
   schemaPath: string;
   documents: Array<string>;
   debug: boolean;
+  disableSchemaTypesGeneration: boolean;
   production: boolean;
   baseDir: string;
   extension: string;
@@ -25,6 +26,11 @@ export async function binMain() {
       '--production',
       'optimize codegen outputs for production builds',
       process.env.NODE_ENV === 'prod'
+    )
+    .option(
+      '--disable-schema-types-generation',
+      'skip generating schema types',
+      false
     )
     .option(
       '--base-dir <baseDir>',

--- a/packages/codegen/src/codegen.ts
+++ b/packages/codegen/src/codegen.ts
@@ -34,6 +34,7 @@ export async function athenaCodegen({
   extension,
   hash,
   debug,
+  disableSchemaTypesGeneration,
   production,
 }: CodegenArgs): Promise<void> {
   const startTime = hrtime.bigint();
@@ -51,14 +52,18 @@ export async function athenaCodegen({
   const graphqlSchema = buildSchema(rawSchema);
   const hashFn = hash || defaultHash;
 
-  // Generate schema types and write to root schema file
+  // User can disable schema type generation (e.g. for cases where they have
+  // already compiled their schema types)
   const schemaTypesOutputPath = changeExtension(schemaPath, extension);
-  const schemaTypes = await generateSchemaTypes(
-    parsedSchema,
-    schemaTypesOutputPath
-  );
+  if (!disableSchemaTypesGeneration) {
+    // Generate schema types and write to root schema file
+    const schemaTypes = await generateSchemaTypes(
+      parsedSchema,
+      schemaTypesOutputPath
+    );
 
-  outputFiles.push(schemaTypes);
+    outputFiles.push(schemaTypes);
+  }
 
   // Expand glob patterns and find matching files
   const paths = await globby([...documents, `!${schemaPath}`]);

--- a/packages/codegen/src/types.ts
+++ b/packages/codegen/src/types.ts
@@ -12,6 +12,7 @@ export interface CodegenArgs {
   documents: Array<string>;
   baseDir: string;
   extension: string;
+  disableSchemaTypesGeneration: boolean;
   debug?: boolean;
   production: boolean;
   hash?: (document: DocumentNode) => string;


### PR DESCRIPTION
This lets us skip schema generation in cases where the schema types are
already generated.

[fix #120]
