### PR TITLE
chore: make it possible to have tests update on src file changes

### DIFF
--- a/packages/athena/vitest.config.ts
+++ b/packages/athena/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
 
 export default defineConfig({
   test: {
     testTimeout: 10_000,
+  },
+  resolve: {
+    alias: {
+      '@data-eden/athena': resolve(__dirname, './src'),
+    },
   },
 });

--- a/packages/cache/vitest.config.ts
+++ b/packages/cache/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
 
 export default defineConfig({
   test: {
     include: ['__tests__/**/*-test.ts'],
     testTimeout: 10_000,
+  },
+  resolve: {
+    alias: {
+      '@data-eden/cache': resolve(__dirname, './src'),
+    },
   },
 });

--- a/packages/codegen/__tests__/babel.test.ts
+++ b/packages/codegen/__tests__/babel.test.ts
@@ -1,5 +1,5 @@
 import { transformFileAsync } from '@babel/core';
-import { babelPlugin } from '../src/babel-plugin.js';
+import { babelPlugin } from '@data-eden/codegen/babel-plugin.js';
 import type { Project } from 'fixturify-project';
 import { describe, expect, test } from 'vitest';
 import {

--- a/packages/codegen/__tests__/codegen.test.ts
+++ b/packages/codegen/__tests__/codegen.test.ts
@@ -6,7 +6,7 @@ import * as fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 import { describe, expect, test } from 'vitest';
-import { athenaCodegen } from '../src/index.js';
+import { athenaCodegen } from '@data-eden/codegen';
 import {
   createFixtures,
   gqlFilesIgnoreMap,

--- a/packages/codegen/vitest.config.ts
+++ b/packages/codegen/vitest.config.ts
@@ -3,12 +3,11 @@ import { resolve } from 'node:path';
 
 export default defineConfig({
   test: {
-    include: ['__tests__/**/*-test.ts'],
     testTimeout: 10_000,
   },
   resolve: {
     alias: {
-      '@data-eden/network': resolve(__dirname, './src'),
+      '@data-eden/codegen': resolve(__dirname, './src'),
     },
   },
 });

--- a/packages/network/__tests__/settled-tracking-middleware-test.ts
+++ b/packages/network/__tests__/settled-tracking-middleware-test.ts
@@ -17,9 +17,7 @@ import {
   getPendingRequestState,
 } from '@data-eden/network';
 
-// TODO: this should actually be import { _setupDefaultRequestsCompletedOptions } from '#settled-tracking-middleware'
-//   but we need https://github.com/vitejs/vite/pull/7770 to land in order to leverage subpath imports properly
-import { _setupDefaultRequestsCompletedOptions } from '@data-eden/network/-private/settled-tracking-middleware';
+import { _setupDefaultRequestsCompletedOptions } from '#settled-tracking-middleware';
 
 import type * as http from 'http';
 
@@ -189,16 +187,16 @@ describe('@data-eden/network: settled-tracking-middleware', async function () {
             {
               "method": "GET",
               "stack": "Error:
-              at SettledTrackingMiddleware (file:///packages/network/src/settled-tracking-middleware.ts)
-              at file:///packages/network/src/fetch.ts",
+              at SettledTrackingMiddleware (/packages/network/src/settled-tracking-middleware.ts)
+              at /packages/network/src/fetch.ts",
               "startTime": 99999999,
               "url": "/resource",
             },
             {
               "method": "GET",
               "stack": "Error:
-              at SettledTrackingMiddleware (file:///packages/network/src/settled-tracking-middleware.ts)
-              at file:///packages/network/src/fetch.ts",
+              at SettledTrackingMiddleware (/packages/network/src/settled-tracking-middleware.ts)
+              at /packages/network/src/fetch.ts",
               "startTime": 99999999,
               "url": "/resource",
             },
@@ -211,16 +209,16 @@ describe('@data-eden/network: settled-tracking-middleware', async function () {
             {
               "method": "GET",
               "stack": "Error:
-              at SettledTrackingMiddleware (file:///packages/network/src/settled-tracking-middleware.ts)
-              at file:///packages/network/src/fetch.ts",
+              at SettledTrackingMiddleware (/packages/network/src/settled-tracking-middleware.ts)
+              at /packages/network/src/fetch.ts",
               "startTime": 99999999,
               "url": "/resource",
             },
             {
               "method": "GET",
               "stack": "Error:
-              at SettledTrackingMiddleware (file:///packages/network/src/settled-tracking-middleware.ts)
-              at file:///packages/network/src/fetch.ts",
+              at SettledTrackingMiddleware (/packages/network/src/settled-tracking-middleware.ts)
+              at /packages/network/src/fetch.ts",
               "startTime": 99999999,
               "url": "/resource",
             },


### PR DESCRIPTION
Talking with @hjdivad we couldn't get src file changes on change.

This was a result of the import in the test being an alias and vite not wanting to watch the path.