### PR TITLE
Add a `$debug` property to the `buildFetch` result.

### DIFF
--- a/internal-packages/shared-test-utilities/src/index.ts
+++ b/internal-packages/shared-test-utilities/src/index.ts
@@ -1,1 +1,23 @@
 export { createServer } from './server.js';
+
+import { fileURLToPath } from 'url';
+import * as path from 'path';
+
+export function sanitizeStacktrace(errorStack: string): string {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const prefix = path.resolve(__dirname, '../../../');
+  const lines = errorStack.split('\n');
+
+  return (
+    lines
+      // only look at the first 3 stack frames to avoid including a bunch of node_modules and whatnot
+      .slice(0, 3)
+      // strip the repo root prefix from the stacks to ensure stable across users
+      .map((line: string) => line.replace(prefix, ''))
+      // strip line:col information
+      .map((line: string) => line.replace(/:\d+:\d+/, ''))
+      // remove trailing whitespace (avoids snapshot instability for editors that auto delete trailing whitespace)
+      .map((line: string) => line.trimEnd())
+      .join('\n')
+  );
+}

--- a/packages/network/src/dev.d.ts
+++ b/packages/network/src/dev.d.ts
@@ -1,0 +1,8 @@
+// internal types only, used for local type casting
+// should **not** be exported
+export type FetchWithDebug = typeof fetch & {
+  $debug: {
+    creationStack: undefined | string;
+    middlewares: Middleware[];
+  };
+};

--- a/packages/network/src/settled-tracking-middleware.ts
+++ b/packages/network/src/settled-tracking-middleware.ts
@@ -1,6 +1,17 @@
+import type { FetchWithDebug as _FetchWithDebug } from './dev.js';
 import type { MiddlewareMetadata, NormalizedFetch } from './fetch.js';
 
 type Fetch = typeof fetch;
+
+type FetchWithDebug = _FetchWithDebug & {
+  $debug: {
+    settledness: {
+      pendingRequestState: FetchDebugInfo[];
+      hasPendingRequests: boolean;
+      requestsCompleted: Promise<unknown>;
+    };
+  };
+};
 
 /**
   Debug information that is exposed via `getPendingRequestState(...)`.
@@ -206,6 +217,26 @@ export default async function SettledTrackingMiddleware(
   const error = new Error();
 
   const originatingFetch = metadata.fetch;
+
+  if (typeof (originatingFetch as FetchWithDebug).$debug !== 'undefined') {
+    const originatingFetchWithDebug = originatingFetch as FetchWithDebug;
+
+    if (originatingFetchWithDebug.$debug.settledness === undefined) {
+      originatingFetchWithDebug.$debug.settledness = {
+        get pendingRequestState() {
+          return getPendingRequestState(originatingFetchWithDebug);
+        },
+
+        get hasPendingRequests() {
+          return hasPendingRequests(originatingFetchWithDebug);
+        },
+
+        get requestsCompleted() {
+          return requestsCompleted(originatingFetchWithDebug);
+        },
+      };
+    }
+  }
 
   let fetchDebugInfos = TrackingInfoPerFetch.get(originatingFetch);
   if (fetchDebugInfos === undefined) {


### PR DESCRIPTION
When using the `fetch` that is returned by `buildFetch` it is often useful to debug individual middlewares or to check if there are any pending requests. The current implementation makes that quite difficult.

This PR adds a new `debug` option to `buildFetch`. As long as `{ debug: false }` isn't explicitly passed, the returned `fetch` function will have a `$debug` property with the following interface:

```typescript
type FetchWithDebug = typeof fetch & {
  $debug: {
    creationStack: string;
    middlewares: Middleware[];
  };
};
```

Additionally, if you are also using the `SettledTrackingMiddleware` you will have even more information available (though only after the first `fetch(...)` invocation).

```typescript
type FetchWithDebug = typeof fetch & {
  $debug: {
    creationStack: string;
    middlewares: Middleware[];
    settledness: {
      pendingRequestState: FetchDebugInfo[];
      hasPendingRequests: boolean;
      requestsCompleted: Promise<void>;
    };
  };
};
```
