### PR TITLE
[cache] split cache classes into separate files

### DIFF
--- a/packages/cache/__tests__/index-test.ts
+++ b/packages/cache/__tests__/index-test.ts
@@ -293,7 +293,7 @@ describe('@data-eden/cache', function () {
         'book:3': { title: 'New Merged book' },
       });
 
-      //Validate Cache before commit
+      // Validate Cache before commit
       expect(await cache.get('book:1')).toEqual({
         'book:1': { title: 'A History of the English speaking peoples' },
       });

--- a/packages/cache/src/cache-revision.ts
+++ b/packages/cache/src/cache-revision.ts
@@ -1,0 +1,90 @@
+import { CacheTransactionImpl } from './cache-transaction.js';
+import type {
+  Cache,
+  CommittingTransaction,
+  CachedEntityRevision,
+  DefaultRegistry,
+  CacheTransactionDebugAPIs,
+} from './index.js';
+
+export class CommittingTransactionImpl<
+    CacheKeyRegistry extends DefaultRegistry,
+    Key extends keyof CacheKeyRegistry = keyof CacheKeyRegistry,
+    $Debug = unknown,
+    UserExtensionData = unknown
+  >
+  extends CacheTransactionImpl<CacheKeyRegistry, Key, $Debug, UserExtensionData>
+  implements
+    CommittingTransaction<CacheKeyRegistry, Key, $Debug, UserExtensionData>
+{
+  #txRetainedEntryRevisions: Map<
+    Key,
+    CachedEntityRevision<CacheKeyRegistry, Key>[]
+  >;
+  $debug?: ($Debug & CacheTransactionDebugAPIs) | undefined;
+  cache: {
+    clearRevisions(id: Key): void;
+    appendRevisions(
+      id: Key,
+      revisions: CachedEntityRevision<CacheKeyRegistry, Key>[]
+    ): void;
+  };
+  mergedEntryRevisions(): Map<
+    Key,
+    CachedEntityRevision<CacheKeyRegistry, Key>[]
+  > {
+    return this.#txRetainedEntryRevisions;
+  }
+  updateRevisions(
+    localRevisionsMap: Map<Key, CachedEntityRevision<CacheKeyRegistry, Key>[]>
+  ): void {
+    this.setLocalRevisions(localRevisionsMap);
+  }
+
+  constructor(
+    originalCache: Cache<CacheKeyRegistry, Key, $Debug, UserExtensionData>,
+    cacheRevisionsBeforeTransaction: Map<
+      Key,
+      CachedEntityRevision<CacheKeyRegistry, Key>[]
+    >
+  ) {
+    super(originalCache);
+
+    this.setRevisionsBeforeTransactionStart(cacheRevisionsBeforeTransaction);
+
+    const appendRevisions = (
+      cacheKey: Key,
+      revisions: CachedEntityRevision<CacheKeyRegistry, Key>[]
+    ) => this.#appendRevisions(cacheKey, revisions);
+
+    const clearRevisions = (cacheKey: Key) => this.#clearRevisions(cacheKey);
+
+    this.cache = {
+      clearRevisions,
+      appendRevisions,
+    };
+    this.#txRetainedEntryRevisions = new Map<
+      Key,
+      CachedEntityRevision<CacheKeyRegistry, Key>[]
+    >();
+  }
+
+  #appendRevisions(
+    cacheKey: Key,
+    revisions: CachedEntityRevision<CacheKeyRegistry, Key>[]
+  ) {
+    if (this.#txRetainedEntryRevisions.has(cacheKey)) {
+      const appendedRevisions =
+        this.#txRetainedEntryRevisions.get(cacheKey)?.concat(revisions) || [];
+      this.#txRetainedEntryRevisions.set(cacheKey, appendedRevisions);
+    } else {
+      this.#txRetainedEntryRevisions.set(cacheKey, revisions);
+    }
+  }
+
+  #clearRevisions(cacheKey: Key) {
+    if (this.#txRetainedEntryRevisions.has(cacheKey)) {
+      this.#txRetainedEntryRevisions.delete(cacheKey);
+    }
+  }
+}

--- a/packages/cache/src/cache-transaction.ts
+++ b/packages/cache/src/cache-transaction.ts
@@ -1,0 +1,251 @@
+import type {
+  Cache,
+  CacheTransaction,
+  CacheEntryState,
+  CachedEntityRevision,
+  DefaultRegistry,
+  ExpirationPolicy,
+} from './index.js';
+
+import { DEFAULT_EXPIRATION } from './cache.js';
+export class CacheTransactionImpl<
+  CacheKeyRegistry extends DefaultRegistry,
+  Key extends keyof CacheKeyRegistry,
+  $Debug = unknown,
+  UserExtensionData = unknown
+> implements CacheTransaction<CacheKeyRegistry, Key, $Debug, UserExtensionData>
+{
+  #originalCacheReference: Cache<
+    CacheKeyRegistry,
+    Key,
+    $Debug,
+    UserExtensionData
+  >;
+  #transactionalCache: Map<Key, CacheKeyRegistry[Key]>;
+  #cacheEntriesBeforeTransaction: Map<Key, CacheKeyRegistry[Key]>;
+  #cacheRevisionsBeforeTransaction: Map<
+    Key,
+    CachedEntityRevision<CacheKeyRegistry, Key>[]
+  >;
+  #ttlPolicy: number;
+  #lruPolicy: number;
+  #userOptionExpirationPolicy: ExpirationPolicy;
+  #localRevisionsMap: Map<Key, CachedEntityRevision<CacheKeyRegistry, Key>[]>;
+  #cacheEntryState: Map<Key, CacheEntryState<UserExtensionData>>;
+
+  constructor(
+    originalCache: Cache<CacheKeyRegistry, Key, $Debug, UserExtensionData>
+  ) {
+    this.#originalCacheReference = originalCache;
+    this.#transactionalCache = new Map<Key, CacheKeyRegistry[Key]>();
+    this.#cacheEntryState = new Map<Key, CacheEntryState<UserExtensionData>>();
+    this.#ttlPolicy = DEFAULT_EXPIRATION.ttl;
+    this.#lruPolicy = DEFAULT_EXPIRATION.lru;
+    this.#userOptionExpirationPolicy =
+      this.#originalCacheReference.getCacheOptions()?.expiration ||
+      DEFAULT_EXPIRATION;
+
+    if (
+      this.#userOptionExpirationPolicy &&
+      this.#userOptionExpirationPolicy?.lru &&
+      typeof this.#userOptionExpirationPolicy.lru === 'number'
+    ) {
+      this.#lruPolicy = this.#userOptionExpirationPolicy.lru;
+    }
+
+    if (
+      this.#userOptionExpirationPolicy &&
+      this.#userOptionExpirationPolicy?.ttl &&
+      typeof this.#userOptionExpirationPolicy.ttl === 'number'
+    ) {
+      this.#ttlPolicy = this.#userOptionExpirationPolicy.ttl;
+    }
+
+    this.#localRevisionsMap = new Map<
+      Key,
+      CachedEntityRevision<CacheKeyRegistry, Key>[]
+    >();
+    this.#cacheRevisionsBeforeTransaction = new Map<
+      Key,
+      CachedEntityRevision<CacheKeyRegistry, Key>[]
+    >();
+
+    this.#cacheEntriesBeforeTransaction = new Map<Key, CacheKeyRegistry[Key]>();
+  }
+
+  protected getExpirationPolicies() {
+    return {
+      userOptionExpirationPolicy: this.#userOptionExpirationPolicy,
+      lruPolicy: this.#lruPolicy,
+      ttlPolicy: this.#ttlPolicy,
+    };
+  }
+
+  protected setLocalRevisionsByEntry(
+    cacheKey: Key,
+    revision: CachedEntityRevision<CacheKeyRegistry, Key>
+  ) {
+    if (this.#localRevisionsMap.has(cacheKey)) {
+      this.#localRevisionsMap.get(cacheKey)?.push(revision);
+    } else {
+      this.#localRevisionsMap.set(cacheKey, [revision]);
+    }
+  }
+
+  protected getLocalRevisions(): Map<
+    Key,
+    CachedEntityRevision<CacheKeyRegistry, Key>[]
+  > {
+    return this.#localRevisionsMap;
+  }
+
+  protected setLocalRevisions(
+    localRevisionsMap: Map<Key, CachedEntityRevision<CacheKeyRegistry, Key>[]>
+  ): Map<Key, CachedEntityRevision<CacheKeyRegistry, Key>[]> {
+    return (this.#localRevisionsMap = localRevisionsMap);
+  }
+
+  protected getLocalRevisionsByEntry(
+    cacheKey: Key
+  ): CachedEntityRevision<CacheKeyRegistry, Key>[] | undefined {
+    return this.#localRevisionsMap.get(cacheKey);
+  }
+
+  protected setRevisionsBeforeTransactionStart(
+    revisions: Map<Key, CachedEntityRevision<CacheKeyRegistry, Key>[]>
+  ) {
+    this.#cacheRevisionsBeforeTransaction = revisions;
+  }
+
+  protected setCacheEntryState(
+    cacheKey: Key,
+    cacheEntryState: CacheEntryState<UserExtensionData>
+  ) {
+    this.#cacheEntryState.set(cacheKey, cacheEntryState);
+  }
+
+  protected getCacheEntryState(
+    cacheKey: Key
+  ): CacheEntryState<UserExtensionData> | undefined {
+    return this.#cacheEntryState.get(cacheKey);
+  }
+
+  protected setCacheEntriesBeforeTransaction(
+    entries: Map<Key, CacheKeyRegistry[Key]>
+  ) {
+    this.#cacheEntriesBeforeTransaction = entries;
+  }
+
+  protected getTransactionalCache() {
+    return this.#transactionalCache;
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<
+    [Key, CacheKeyRegistry[Key], CacheEntryState<UserExtensionData>]
+  > {
+    for await (const [key, value] of this.localEntries()) {
+      const state = this.#cacheEntryState.get(
+        key
+      ) as CacheEntryState<UserExtensionData>;
+      yield [key, value, state];
+    }
+  }
+
+  async get(cacheKey: Key): Promise<CacheKeyRegistry[Key] | undefined> {
+    // will check the transaction entries and fall back to the cache if the transaction hasn't written to the key yet.
+    let cachedValue;
+
+    for await (const [key, value] of this.localEntries()) {
+      if (key === cacheKey) {
+        cachedValue = value;
+        break;
+      }
+    }
+
+    // Update cache entry state
+    this.#cacheEntryState.set(cacheKey, {
+      retained: { lru: true, ttl: this.#ttlPolicy },
+      lastAccessed: Date.now(),
+    });
+
+    return cachedValue || (await this.#originalCacheReference.get(cacheKey));
+  }
+
+  localEntries(): AsyncIterableIterator<[Key, CacheKeyRegistry[Key]]> {
+    const localEntriesIterator = {
+      async *[Symbol.asyncIterator](
+        localEntryMap: Map<Key, CacheKeyRegistry[Key]>
+      ): AsyncIterableIterator<[Key, CacheKeyRegistry[Key]]> {
+        for (const [key, value] of localEntryMap) {
+          yield [key, value];
+        }
+      },
+    };
+    return localEntriesIterator[Symbol.asyncIterator](this.#transactionalCache);
+  }
+
+  async entries(): Promise<
+    AsyncIterableIterator<[Key, CacheKeyRegistry[Key]]>
+  > {
+    const entriesIterator = {
+      async *[Symbol.asyncIterator](
+        localEntriesIterator: AsyncIterableIterator<
+          [Key, CacheKeyRegistry[Key]]
+        >,
+        cacheEntriesBeforeTransaction: Map<Key, CacheKeyRegistry[Key]>
+      ): AsyncIterableIterator<[Key, CacheKeyRegistry[Key]]> {
+        for await (const [key, transactionValue] of localEntriesIterator) {
+          yield [key, transactionValue];
+          const cacheValue = cacheEntriesBeforeTransaction.get(key);
+          if (cacheValue) {
+            yield [key, cacheValue];
+          }
+        }
+      },
+    };
+
+    return entriesIterator[Symbol.asyncIterator](
+      this.localEntries(),
+      this.#cacheEntriesBeforeTransaction
+    );
+  }
+
+  localRevisions(
+    cacheKey: Key
+  ): AsyncIterableIterator<CachedEntityRevision<CacheKeyRegistry, Key>> {
+    const entryRevisionIterator = {
+      async *[Symbol.asyncIterator](
+        revisions: CachedEntityRevision<CacheKeyRegistry, Key>[]
+      ): AsyncIterableIterator<CachedEntityRevision<CacheKeyRegistry, Key>> {
+        for (const revision of revisions) {
+          yield revision;
+        }
+      },
+    };
+
+    const revisions = this.#localRevisionsMap.get(cacheKey) || [];
+    return entryRevisionIterator[Symbol.asyncIterator](revisions);
+  }
+
+  entryRevisions(
+    cacheKey: Key
+  ): AsyncIterableIterator<CachedEntityRevision<CacheKeyRegistry, Key>> {
+    const entryRevisionIterator = {
+      async *[Symbol.asyncIterator](
+        revisions: CachedEntityRevision<CacheKeyRegistry, Key>[]
+      ): AsyncIterableIterator<CachedEntityRevision<CacheKeyRegistry, Key>> {
+        for (const revision of revisions) {
+          yield revision;
+        }
+      },
+    };
+
+    const entryRevisions =
+      this.#cacheRevisionsBeforeTransaction.get(cacheKey) || [];
+    const localRevisions = this.#localRevisionsMap.get(cacheKey) || [];
+
+    return entryRevisionIterator[Symbol.asyncIterator](
+      entryRevisions.concat(localRevisions)
+    );
+  }
+}

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -1,3 +1,5 @@
+import { LiveCacheTransactionImpl } from './live-transaction.js';
+import { CommittingTransactionImpl } from './cache-revision.js';
 import type {
   Cache,
   CacheTransaction,
@@ -7,19 +9,18 @@ import type {
   CacheEntryState,
   CacheKeyValue,
   CachedEntityRevision,
-  ExpirationPolicy,
   CacheOptions,
   DefaultRegistry,
   LruCache,
-  CacheTransactionDebugAPIs,
-  EntityMergeStrategy,
-  // RevisionMergeStrategy,
   TransactionUpdates,
-  TransactionOperations,
   DeferredTransactionLock,
 } from './index.js';
 
-let REVISION_COUNTER = 0;
+export const DEFAULT_EXPIRATION = { lru: 10000, ttl: 60000 };
+
+export const DEFAULT_ENTRY_STATE = {
+  retained: { lru: false, ttl: DEFAULT_EXPIRATION.ttl },
+};
 
 class CacheImpl<
   CacheKeyRegistry extends DefaultRegistry,
@@ -37,6 +38,12 @@ class CacheImpl<
   #lruCache: LruCacheImpl<CacheKeyRegistry, Key>;
   #lruPolicy: number;
   #cleanup: FinalizationRegistry<Key>;
+  #cacheRevisionTransaction!: CommittingTransaction<
+    CacheKeyRegistry,
+    Key,
+    $Debug,
+    UserExtensionData
+  >;
 
   #txCommitLockOwner: LiveCacheTransaction<
     CacheKeyRegistry,
@@ -58,7 +65,18 @@ class CacheImpl<
       | undefined
   ) {
     this.#weakCache = new Map<Key, WeakRef<CacheKeyRegistry[Key]>>();
-    this.#cacheOptions = options;
+
+    this.#cacheOptions = {
+      hooks: {
+        commit: options?.hooks?.commit,
+        entitymergeStrategy:
+          options?.hooks?.entitymergeStrategy || defaultMergeStrategy,
+        revisionMergeStrategy:
+          options?.hooks?.revisionMergeStrategy || defaultRetensionStrategy,
+      },
+      expiration: options?.expiration || DEFAULT_EXPIRATION,
+    };
+
     this.#lruPolicy = DEFAULT_EXPIRATION.lru;
     this.#entryRevisions = new Map<
       Key,
@@ -160,6 +178,7 @@ class CacheImpl<
         entity: value,
         revision: ++revisionCounter,
       };
+
       if (this.#entryRevisions.has(key)) {
         const revisions =
           this.#entryRevisions.get(key)?.concat(entityRevision) || [];
@@ -263,7 +282,7 @@ class CacheImpl<
     };
   }
 
-  #aquireTxCommitLock(
+  async #aquireTxCommitLock(
     transaction: LiveCacheTransaction<
       CacheKeyRegistry,
       Key,
@@ -303,6 +322,22 @@ class CacheImpl<
     }
   }
 
+  async #applyRetentionPolicies(
+    cacheKey: Key,
+    liveTx: LiveCacheTransaction<
+      CacheKeyRegistry,
+      Key,
+      $Debug,
+      UserExtensionData
+    >
+  ): Promise<void> {
+    const revisionStrategy =
+      this.#cacheOptions?.hooks?.revisionMergeStrategy ||
+      defaultRetensionStrategy;
+
+    await revisionStrategy(cacheKey, this.#cacheRevisionTransaction);
+  }
+
   #commitUpdatesAndReleaseLock(
     transaction: LiveCacheTransaction<
       CacheKeyRegistry,
@@ -338,14 +373,11 @@ class CacheImpl<
     }
 
     // Write transaction revisions entries to the main cache
-    for (const [cacheKey, revision] of txUpdates.entryRevisions) {
-      if (this.#entryRevisions.has(cacheKey)) {
-        const revisions =
-          this.#entryRevisions.get(cacheKey)?.concat(revision) || [];
-        this.#entryRevisions.set(cacheKey, revisions);
-      } else {
-        this.#entryRevisions.set(cacheKey, revision);
-      }
+    for (const [
+      cacheKey,
+      revision,
+    ] of this.#cacheRevisionTransaction.mergedEntryRevisions()) {
+      this.#entryRevisions.set(cacheKey, revision);
     }
 
     this.#releaseTxCommitLock(transaction);
@@ -371,6 +403,12 @@ class CacheImpl<
 
       waitingTxDeferred.resolve();
     }
+  }
+
+  #updateSavedRevisions(
+    localRevisionsMap: Map<Key, CachedEntityRevision<CacheKeyRegistry, Key>[]>
+  ) {
+    this.#cacheRevisionTransaction?.updateRevisions(localRevisionsMap);
   }
 
   async beginTransaction(): Promise<
@@ -404,485 +442,64 @@ class CacheImpl<
       txUpdates: TransactionUpdates<CacheKeyRegistry, Key, UserExtensionData>
     ) => this.#commitUpdatesAndReleaseLock(transaction, txUpdates);
 
-    return new LiveCacheTransactionImpl<
-      CacheKeyRegistry,
+    const applyRetentionPolicies = (
+      cacheKey: Key,
+      liveTx: LiveCacheTransaction<
+        CacheKeyRegistry,
+        Key,
+        $Debug,
+        UserExtensionData
+      >
+    ) => this.#applyRetentionPolicies(cacheKey, liveTx);
+
+    const updateSavedRevisions = (
+      localRevisionsMap: Map<Key, CachedEntityRevision<CacheKeyRegistry, Key>[]>
+    ) => this.#updateSavedRevisions(localRevisionsMap);
+
+    const cacheEntriesBeforeTransaction = new Map<Key, CacheKeyRegistry[Key]>();
+    const cacheRevisionsBeforeTransaction = new Map<
       Key,
-      $Debug,
-      UserExtensionData
-    >(this, {
+      CachedEntityRevision<CacheKeyRegistry, Key>[]
+    >();
+
+    for await (const [cacheKey, value] of this.entries()) {
+      cacheEntriesBeforeTransaction.set(cacheKey, value);
+    }
+
+    for await (const [cacheKey] of this.entries()) {
+      const revisions: CachedEntityRevision<CacheKeyRegistry, Key>[] = [];
+      for await (const revision of this.entryRevisions(cacheKey)) {
+        revisions.push(revision);
+      }
+      cacheRevisionsBeforeTransaction.set(cacheKey, revisions);
+    }
+
+    const transactionOperations = {
       aquireTxCommitLock,
       releaseTxCommitLock,
+      applyRetentionPolicies,
+      updateSavedRevisions,
       commitUpdatesAndReleaseLock,
-    });
-  }
-}
+    };
 
-class LiveCacheTransactionImpl<
-  CacheKeyRegistry extends DefaultRegistry,
-  Key extends keyof CacheKeyRegistry,
-  $Debug = unknown,
-  UserExtensionData = unknown
-> implements
-    LiveCacheTransaction<CacheKeyRegistry, Key, $Debug, UserExtensionData>
-{
-  #originalCacheReference: CacheImpl<
-    CacheKeyRegistry,
-    Key,
-    $Debug,
-    UserExtensionData
-  >;
-  #transactionalCache: Map<Key, CacheKeyRegistry[Key]>;
-  #commitingTransaction: CommittingTransactionImpl<
-    CacheKeyRegistry,
-    Key,
-    $Debug,
-    UserExtensionData
-  >;
-  #cacheEntryState: Map<Key, CacheEntryState<UserExtensionData>>;
-  #userOptionRetentionPolicy: ExpirationPolicy;
-  #ttlPolicy: number;
-  #lruPolicy: number;
-  #localRevisions: Map<Key, CachedEntityRevision<CacheKeyRegistry, Key>[]>;
-  #entryRevisions: Map<Key, CachedEntityRevision<CacheKeyRegistry, Key>[]>;
-  #transactionOperations: TransactionOperations<
-    CacheKeyRegistry,
-    Key,
-    $Debug,
-    UserExtensionData
-  >;
+    this.#cacheRevisionTransaction = new CommittingTransactionImpl(
+      this,
+      cacheRevisionsBeforeTransaction
+    );
 
-  constructor(
-    originalCache: CacheImpl<CacheKeyRegistry, Key, $Debug, UserExtensionData>,
-    transactionOperations: TransactionOperations<
+    const liveTx = new LiveCacheTransactionImpl<
       CacheKeyRegistry,
       Key,
       $Debug,
       UserExtensionData
-    >
-  ) {
-    this.#originalCacheReference = originalCache;
-    this.#transactionalCache = new Map<Key, CacheKeyRegistry[Key]>();
-    this.#cacheEntryState = new Map<Key, CacheEntryState<UserExtensionData>>();
-    this.#ttlPolicy = DEFAULT_EXPIRATION.ttl;
-    this.#lruPolicy = DEFAULT_EXPIRATION.lru;
-    this.#localRevisions = new Map<
-      Key,
-      CachedEntityRevision<CacheKeyRegistry, Key>[]
-    >();
-    this.#entryRevisions = new Map<
-      Key,
-      CachedEntityRevision<CacheKeyRegistry, Key>[]
-    >();
-    this.#userOptionRetentionPolicy =
-      this.#originalCacheReference.getCacheOptions()?.expiration ||
-      DEFAULT_EXPIRATION;
-
-    if (
-      this.#userOptionRetentionPolicy &&
-      this.#userOptionRetentionPolicy?.lru &&
-      typeof this.#userOptionRetentionPolicy.lru === 'number'
-    ) {
-      this.#lruPolicy = this.#userOptionRetentionPolicy.lru;
-    }
-
-    if (
-      this.#userOptionRetentionPolicy &&
-      this.#userOptionRetentionPolicy?.ttl &&
-      typeof this.#userOptionRetentionPolicy.ttl === 'number'
-    ) {
-      this.#ttlPolicy = this.#userOptionRetentionPolicy.ttl;
-    }
-
-    this.#commitingTransaction = new CommittingTransactionImpl<
-      CacheKeyRegistry,
-      Key,
-      $Debug,
-      UserExtensionData
-    >();
-
-    this.#transactionOperations = transactionOperations;
-  }
-
-  async *[Symbol.asyncIterator](): AsyncIterableIterator<
-    [Key, CacheKeyRegistry[Key], CacheEntryState<UserExtensionData>]
-  > {
-    for await (const [key, value] of this.localEntries()) {
-      const state = this.#cacheEntryState.get(
-        key
-      ) as CacheEntryState<UserExtensionData>;
-      yield [key, value, state];
-    }
-  }
-
-  async get(cacheKey: Key): Promise<CacheKeyRegistry[Key] | undefined> {
-    // will check the transaction entries and fall back to the cache if the transaction hasn't written to the key yet.
-    let cachedValue;
-
-    for await (const [key, value] of this.localEntries()) {
-      if (key === cacheKey) {
-        cachedValue = value;
-        break;
-      }
-    }
-
-    return cachedValue || (await this.#originalCacheReference.get(cacheKey));
-  }
-
-  localEntries(): AsyncIterableIterator<[Key, CacheKeyRegistry[Key]]> {
-    const localEntriesIterator = {
-      async *[Symbol.asyncIterator](
-        localEntryMap: Map<Key, CacheKeyRegistry[Key]>
-      ): AsyncIterableIterator<[Key, CacheKeyRegistry[Key]]> {
-        for (const [key, value] of localEntryMap) {
-          yield [key, value];
-        }
-      },
-    };
-    return localEntriesIterator[Symbol.asyncIterator](this.#transactionalCache);
-  }
-
-  async entries(): Promise<
-    AsyncIterableIterator<[Key, CacheKeyRegistry[Key]]>
-  > {
-    const entriesIterator = {
-      async *[Symbol.asyncIterator](
-        localEntriesIterator: AsyncIterableIterator<
-          [Key, CacheKeyRegistry[Key]]
-        >,
-        cacheRef: CacheImpl<CacheKeyRegistry, Key, $Debug, UserExtensionData>
-      ): AsyncIterableIterator<[Key, CacheKeyRegistry[Key]]> {
-        for await (const [key, transactionValue] of localEntriesIterator) {
-          yield [key, transactionValue];
-          const cacheValue = await cacheRef.get(key);
-          if (cacheValue) {
-            yield [key, cacheValue];
-          }
-        }
-      },
-    };
-
-    return entriesIterator[Symbol.asyncIterator](
-      this.localEntries(),
-      this.#originalCacheReference
+    >(
+      this,
+      cacheEntriesBeforeTransaction,
+      cacheRevisionsBeforeTransaction,
+      transactionOperations
     );
-  }
 
-  localRevisions(
-    cacheKey: Key
-  ): AsyncIterableIterator<CachedEntityRevision<CacheKeyRegistry, Key>> {
-    const entryRevisionIterator = {
-      async *[Symbol.asyncIterator](
-        revisions: CachedEntityRevision<CacheKeyRegistry, Key>[]
-      ): AsyncIterableIterator<CachedEntityRevision<CacheKeyRegistry, Key>> {
-        for (const revision of revisions) {
-          yield revision;
-        }
-      },
-    };
-
-    const revisions = this.#localRevisions.get(cacheKey) || [];
-    return entryRevisionIterator[Symbol.asyncIterator](revisions);
-  }
-
-  entryRevisions(
-    cacheKey: Key
-  ): AsyncIterableIterator<CachedEntityRevision<CacheKeyRegistry, Key>> {
-    const entryRevisionIterator = {
-      async *[Symbol.asyncIterator](
-        revisions: CachedEntityRevision<CacheKeyRegistry, Key>[]
-      ): AsyncIterableIterator<CachedEntityRevision<CacheKeyRegistry, Key>> {
-        for (const revision of revisions) {
-          yield revision;
-        }
-      },
-    };
-
-    const entryRevisions = this.#entryRevisions.get(cacheKey) || [];
-    const localRevisions = this.#localRevisions.get(cacheKey) || [];
-
-    return entryRevisionIterator[Symbol.asyncIterator](
-      entryRevisions.concat(localRevisions)
-    );
-  }
-
-  async set(
-    cacheKey: Key,
-    value: CacheKeyRegistry[Key]
-  ): Promise<CacheKeyRegistry[Key]> {
-    this.#transactionalCache.set(cacheKey, value);
-
-    // Update cache entry state
-    this.#cacheEntryState.set(cacheKey, {
-      retained: { lru: true, ttl: this.#ttlPolicy },
-      lastAccessed: Date.now(),
-    });
-
-    return (await this.get(cacheKey)) as CacheKeyRegistry[Key];
-  }
-
-  async delete(cacheKey: Key): Promise<boolean> {
-    // tx.delete will actually need to write a tombstone in the transaction entries and the actual delete will occur when the transaction is committed to the cache.
-    // The semantics of tx.delete's return value should be "did i delete something?"
-    if (await this.get(cacheKey)) {
-      this.#transactionalCache.delete(cacheKey);
-
-      // Update cache entry state to indicate as delete in order to actually be deleted from cache when commit
-      this.#cacheEntryState.set(cacheKey, {
-        retained: { lru: false, ttl: 0 },
-        deletedRecordInTransaction: true,
-        lastAccessed: Date.now(),
-      });
-      return true;
-    }
-
-    return false;
-  }
-
-  // assign transaction or cache level overriden merge strategy else use default
-  #getMergeStrategy(
-    transactionMergeStrategy?: EntityMergeStrategy<
-      CacheKeyRegistry,
-      Key,
-      $Debug,
-      UserExtensionData
-    >
-  ) {
-    const cacheWideMergeStrategy =
-      this.#originalCacheReference.getCacheOptions()?.hooks
-        ?.entitymergeStrategy;
-
-    return (
-      transactionMergeStrategy || cacheWideMergeStrategy || defaultMergeStrategy
-    );
-  }
-
-  #getRevisionStrategy() {
-    const cacheWideRevisionStrategy =
-      this.#originalCacheReference.getCacheOptions()?.hooks
-        ?.revisionMergeStrategy;
-
-    return cacheWideRevisionStrategy || defaultRevisionStrategy;
-  }
-
-  async merge(
-    cacheKey: Key,
-    entity: CacheKeyRegistry[Key],
-    options?: {
-      entityMergeStrategy: EntityMergeStrategy<
-        CacheKeyRegistry,
-        Key,
-        $Debug,
-        UserExtensionData
-      >;
-      revisionContext: string;
-      $debug: $Debug;
-    }
-  ): Promise<CacheKeyRegistry[Key] | CacheKeyValue> {
-    const mergeStrategy = this.#getMergeStrategy(options?.entityMergeStrategy);
-
-    // get current cache value within this transaction
-    const currentValue = await this.#originalCacheReference.get(cacheKey);
-    const revisionCounter = REVISION_COUNTER++;
-
-    // get merged entity
-    const mergedEntity = currentValue
-      ? entity
-      : mergeStrategy(
-          cacheKey,
-          {
-            entity,
-            revision: REVISION_COUNTER++,
-            revisionContext: options?.revisionContext,
-          },
-          currentValue,
-          this
-        );
-
-    // Update transactional cache with merged entity
-    // Calling set here will in turn also update cacheEntryState
-    await this.set(cacheKey, mergedEntity as CacheKeyRegistry[Key]);
-
-    // Update local & entry revisions with new revision values
-    const revision = {
-      entity: mergedEntity as CacheKeyRegistry[Key],
-      revision: revisionCounter,
-      revisionContext: options?.revisionContext,
-    };
-    if (this.#localRevisions.has(cacheKey)) {
-      this.#localRevisions.get(cacheKey)?.push(revision);
-    } else {
-      this.#localRevisions.set(cacheKey, [revision]);
-    }
-
-    return mergedEntity;
-  }
-
-  async #prepareTransaction(): Promise<
-    TransactionUpdates<CacheKeyRegistry, Key, UserExtensionData>
-  > {
-    const trasactionCacheEntries: [
-      Key,
-      CacheKeyRegistry[Key],
-      CacheEntryState<UserExtensionData>
-    ][] = [];
-
-    for await (const [cacheKey, value] of this.localEntries()) {
-      const latestCacheValue = await this.#originalCacheReference.get(cacheKey);
-      let mergedEntityToCommit;
-      const mergeStrategy = this.#getMergeStrategy();
-
-      if (latestCacheValue) {
-        // TODO fix revision
-        mergedEntityToCommit = mergeStrategy(
-          cacheKey,
-          { entity: value, revision: 3 },
-          latestCacheValue,
-          this
-        );
-      } else {
-        mergedEntityToCommit = value;
-      }
-      const structuredClonedValue = structuredClone(
-        mergedEntityToCommit
-      ) as CacheKeyRegistry[Key];
-
-      const state = this.#cacheEntryState.get(cacheKey) || DEFAULT_ENTRY_STATE;
-
-      trasactionCacheEntries.push([cacheKey, structuredClonedValue, state]);
-
-      // Update saved revisions of the entity
-      const localRevisions = this.#localRevisions.get(cacheKey);
-      let revisionNumber =
-        localRevisions && localRevisions[localRevisions.length - 1].revision
-          ? localRevisions[localRevisions.length - 1].revision
-          : 0;
-
-      const entityRevision = {
-        entity: mergedEntityToCommit as CacheKeyRegistry[Key],
-        revision: ++revisionNumber,
-      };
-      if (this.#localRevisions.has(cacheKey)) {
-        this.#localRevisions.get(cacheKey)?.push(entityRevision);
-      } else {
-        this.#localRevisions.set(cacheKey, [entityRevision]);
-      }
-
-      const revisionStrategy = this.#getRevisionStrategy();
-
-      // Update revisions based on revision strategy
-      await revisionStrategy(cacheKey, this.#commitingTransaction, this);
-    }
-
-    // Call commit hook to apply custom retention policies before commit (if passed by cache options)
-    const commitCallback =
-      this.#originalCacheReference.getCacheOptions()?.hooks?.commit;
-    if (commitCallback) {
-      await commitCallback(this);
-    }
-
-    const mergedRevisions = this.#commitingTransaction.mergedRevisions();
-    return {
-      entries: trasactionCacheEntries,
-      entryRevisions: mergedRevisions,
-    };
-  }
-
-  async commit(options?: { timeout: number | false }): Promise<void> {
-    await this.#transactionOperations.aquireTxCommitLock(this);
-
-    let transactionUpdates;
-    try {
-      transactionUpdates = await this.#prepareTransaction();
-      return this.#transactionOperations.commitUpdatesAndReleaseLock(
-        this,
-        transactionUpdates
-      );
-    } catch (e) {
-      throw new Error('Failed to prepare transaction updates');
-    } finally {
-      this.#transactionOperations.releaseTxCommitLock(this);
-    }
-  }
-}
-
-class CommittingTransactionImpl<
-  CacheKeyRegistry extends DefaultRegistry,
-  Key extends keyof CacheKeyRegistry = keyof CacheKeyRegistry,
-  $Debug = unknown,
-  UserExtensionData = unknown
-> implements
-    CommittingTransaction<CacheKeyRegistry, Key, $Debug, UserExtensionData>
-{
-  $debug?: ($Debug & CacheTransactionDebugAPIs) | undefined;
-  #mergedRevisions: Map<Key, CachedEntityRevision<CacheKeyRegistry, Key>[]>;
-  cache: {
-    clearRevisions(
-      tx: CommittingTransactionImpl<
-        CacheKeyRegistry,
-        Key,
-        $Debug,
-        UserExtensionData
-      >,
-      id: Key
-    ): void;
-    appendRevisions(
-      tx: CommittingTransactionImpl<
-        CacheKeyRegistry,
-        Key,
-        $Debug,
-        UserExtensionData
-      >,
-      id: Key,
-      revisions: CachedEntityRevision<CacheKeyRegistry, Key>[]
-    ): void;
-  } = {
-    clearRevisions(
-      tx: CommittingTransactionImpl<
-        CacheKeyRegistry,
-        Key,
-        $Debug,
-        UserExtensionData
-      >,
-      id: Key
-    ): void {
-      tx.#mergedRevisions.delete(id);
-    },
-
-    appendRevisions(
-      tx: CommittingTransactionImpl<
-        CacheKeyRegistry,
-        Key,
-        $Debug,
-        UserExtensionData
-      >,
-      id: Key,
-      revisions: CachedEntityRevision<CacheKeyRegistry, Key>[]
-    ): void {
-      if (tx.#mergedRevisions.has(id)) {
-        const appendedRevisions =
-          tx.#mergedRevisions.get(id)?.concat(revisions) || [];
-        tx.#mergedRevisions.set(id, appendedRevisions);
-      } else {
-        tx.#mergedRevisions.set(id, revisions);
-      }
-    },
-  };
-
-  constructor() {
-    this.#mergedRevisions = new Map<
-      Key,
-      CachedEntityRevision<CacheKeyRegistry, Key>[]
-    >();
-  }
-
-  [Symbol.asyncIterator](): AsyncIterableIterator<
-    [Key, CacheKeyRegistry[Key], CacheEntryState<UserExtensionData>]
-  > {
-    throw new Error('Method not implemented.');
-  }
-
-  mergedRevisions(): Map<Key, CachedEntityRevision<CacheKeyRegistry, Key>[]> {
-    return this.#mergedRevisions;
+    return liveTx;
   }
 }
 
@@ -930,10 +547,27 @@ class LruCacheImpl<
   }
 }
 
-const DEFAULT_EXPIRATION = { lru: 10000, ttl: 60000 };
+const defaultRetensionStrategy = async function retainAllRevisions<
+  CacheKeyRegistry extends DefaultRegistry,
+  Key extends keyof CacheKeyRegistry,
+  $Debug = unknown,
+  UserExtensionData = unknown
+>(
+  id: Key,
+  commitingRevisionTx: CommittingTransaction<
+    CacheKeyRegistry,
+    Key,
+    $Debug,
+    UserExtensionData
+  >
+): Promise<void> {
+  const revisions: CachedEntityRevision<CacheKeyRegistry, Key>[] = [];
 
-const DEFAULT_ENTRY_STATE = {
-  retained: { lru: false, ttl: DEFAULT_EXPIRATION.ttl },
+  for await (const revision of commitingRevisionTx.entryRevisions(id)) {
+    revisions.push(revision);
+  }
+
+  commitingRevisionTx.cache.appendRevisions(id, [...revisions]);
 };
 
 const defaultMergeStrategy = function deepMergeStratey<
@@ -946,35 +580,6 @@ const defaultMergeStrategy = function deepMergeStratey<
   tx: CacheTransaction<CacheKeyRegistry, Key>
 ): CacheKeyValue {
   return deepMerge(current as CacheKeyValue, entity as CacheKeyValue);
-};
-
-const defaultRevisionStrategy = async function retainAllRevisions<
-  CacheKeyRegistry extends DefaultRegistry,
-  Key extends keyof CacheKeyRegistry,
-  $Debug = unknown,
-  UserExtensionData = unknown
->(
-  id: Key,
-  commitTx: CommittingTransactionImpl<
-    CacheKeyRegistry,
-    Key,
-    $Debug,
-    UserExtensionData
-  >,
-  liveTx: LiveCacheTransactionImpl<
-    CacheKeyRegistry,
-    Key,
-    $Debug,
-    UserExtensionData
-  >
-): Promise<void> {
-  const revisions: CachedEntityRevision<CacheKeyRegistry, Key>[] = [];
-
-  for await (const revision of liveTx.localRevisions(id)) {
-    revisions.push(revision);
-  }
-
-  commitTx.cache.appendRevisions(commitTx, id, [...revisions]);
 };
 
 // eslint-disable-next-line

--- a/packages/cache/src/live-transaction.ts
+++ b/packages/cache/src/live-transaction.ts
@@ -1,0 +1,291 @@
+import { CacheTransactionImpl } from './cache-transaction.js';
+import type {
+  Cache,
+  LiveCacheTransaction,
+  CacheEntryState,
+  CacheKeyValue,
+  CachedEntityRevision,
+  ExpirationPolicy,
+  DefaultRegistry,
+  EntityMergeStrategy,
+  TransactionOperations,
+} from './index.js';
+import { DEFAULT_ENTRY_STATE } from './cache.js';
+
+const REVISION_COUNTER = 0;
+
+export class LiveCacheTransactionImpl<
+    CacheKeyRegistry extends DefaultRegistry,
+    Key extends keyof CacheKeyRegistry,
+    $Debug = unknown,
+    UserExtensionData = unknown
+  >
+  extends CacheTransactionImpl<CacheKeyRegistry, Key, $Debug, UserExtensionData>
+  implements
+    LiveCacheTransaction<CacheKeyRegistry, Key, $Debug, UserExtensionData>
+{
+  #originalCacheReference: Cache<
+    CacheKeyRegistry,
+    Key,
+    $Debug,
+    UserExtensionData
+  >;
+  #transactionalCache: Map<Key, CacheKeyRegistry[Key]>;
+  #userOptionRetentionPolicy: ExpirationPolicy;
+  #ttlPolicy: number;
+  #lruPolicy: number;
+  #revisionContext: unknown;
+
+  #transactionOperations: TransactionOperations<
+    CacheKeyRegistry,
+    Key,
+    $Debug,
+    UserExtensionData
+  >;
+
+  constructor(
+    originalCache: Cache<CacheKeyRegistry, Key, $Debug, UserExtensionData>,
+    cacheEntriesBeforeTransaction: Map<Key, CacheKeyRegistry[Key]>,
+    cacheRevisionsBeforeTransaction: Map<
+      Key,
+      CachedEntityRevision<CacheKeyRegistry, Key>[]
+    >,
+    transactionOperations: TransactionOperations<
+      CacheKeyRegistry,
+      Key,
+      $Debug,
+      UserExtensionData
+    >
+  ) {
+    super(originalCache);
+
+    this.#originalCacheReference = originalCache;
+    this.#transactionOperations = transactionOperations;
+
+    this.#transactionalCache = this.getTransactionalCache();
+    // this.#cacheEntryState = this.cacheEntryState;
+
+    this.setCacheEntriesBeforeTransaction(cacheEntriesBeforeTransaction);
+    this.setRevisionsBeforeTransactionStart(cacheRevisionsBeforeTransaction);
+    const { userOptionExpirationPolicy, lruPolicy, ttlPolicy } =
+      this.getExpirationPolicies();
+    this.#ttlPolicy = ttlPolicy;
+    this.#lruPolicy = lruPolicy;
+    this.#userOptionRetentionPolicy = userOptionExpirationPolicy;
+  }
+
+  async set(
+    cacheKey: Key,
+    value: CacheKeyRegistry[Key]
+  ): Promise<CacheKeyRegistry[Key]> {
+    this.#transactionalCache.set(cacheKey, value);
+
+    this.setCacheEntryState(cacheKey, {
+      retained: { lru: true, ttl: this.#ttlPolicy },
+      lastAccessed: Date.now(),
+    });
+
+    return (await this.get(cacheKey)) as CacheKeyRegistry[Key];
+  }
+
+  async delete(cacheKey: Key): Promise<boolean> {
+    // tx.delete will actually need to write a tombstone in the transaction entries and the actual delete will occur when the transaction is committed to the cache.
+    // The semantics of tx.delete's return value should be "did i delete something?"
+    if (await this.get(cacheKey)) {
+      this.#transactionalCache.delete(cacheKey);
+
+      // Update cache entry state to indicate as delete in order to actually be deleted from cache when commit
+      this.setCacheEntryState(cacheKey, {
+        retained: { lru: false, ttl: 0 },
+        deletedRecordInTransaction: true,
+        lastAccessed: Date.now(),
+      });
+      return true;
+    }
+
+    return false;
+  }
+
+  async merge(
+    cacheKey: Key,
+    entity: CacheKeyRegistry[Key],
+    options?: {
+      entityMergeStrategy: EntityMergeStrategy<
+        CacheKeyRegistry,
+        Key,
+        $Debug,
+        UserExtensionData
+      >;
+      revisionContext: unknown;
+      $debug: $Debug;
+    }
+  ): Promise<CacheKeyRegistry[Key] | CacheKeyValue> {
+    this.#revisionContext = options?.revisionContext;
+    const mergeStrategy = this.#getMergeStrategy(options?.entityMergeStrategy);
+
+    // get current cache value within this transaction
+    const currentValue = await this.#originalCacheReference.get(cacheKey);
+    const localRevisionsByEntry = this.getLocalRevisionsByEntry(cacheKey);
+
+    let revisionNumber =
+      localRevisionsByEntry &&
+      localRevisionsByEntry[localRevisionsByEntry.length - 1].revision
+        ? localRevisionsByEntry[localRevisionsByEntry.length - 1].revision
+        : REVISION_COUNTER;
+
+    revisionNumber = ++revisionNumber;
+
+    // get merged entity
+    const mergedEntity = currentValue
+      ? mergeStrategy(
+          cacheKey,
+          {
+            entity,
+            revision: revisionNumber,
+            revisionContext: this.#revisionContext,
+          },
+          currentValue,
+          this
+        )
+      : entity;
+
+    // Update transactional cache with merged entity
+    // Calling set here will in turn also update cacheEntryState
+    await this.set(cacheKey, mergedEntity as CacheKeyRegistry[Key]);
+
+    // Update local & entry revisions with new revision values
+    const revision = {
+      entity: mergedEntity as CacheKeyRegistry[Key],
+      revision: revisionNumber,
+      revisionContext: this.#revisionContext,
+    };
+
+    this.setLocalRevisionsByEntry(cacheKey, revision);
+
+    this.#transactionOperations.updateSavedRevisions(this.getLocalRevisions());
+
+    return mergedEntity;
+  }
+
+  async commit(options?: { timeout: number | false }): Promise<void> {
+    await this.#transactionOperations.aquireTxCommitLock(this);
+
+    let transactionUpdates;
+    try {
+      transactionUpdates = await this.#prepareTransaction();
+      return this.#transactionOperations.commitUpdatesAndReleaseLock(
+        this,
+        transactionUpdates
+      );
+    } catch (e) {
+      throw new Error('Failed to prepare transaction updates');
+    } finally {
+      this.#transactionOperations.releaseTxCommitLock(this);
+    }
+  }
+
+  async #prepareTransaction() {
+    const trasactionCacheEntries: [
+      Key,
+      CacheKeyRegistry[Key],
+      CacheEntryState<UserExtensionData>
+    ][] = [];
+
+    for await (const [cacheKey, value] of this.localEntries()) {
+      const latestCacheValue = await this.#originalCacheReference.get(cacheKey);
+      let mergedEntityToCommit;
+      const mergeStrategy = this.#getMergeStrategy();
+
+      const localRevisionsByEntry = this.getLocalRevisionsByEntry(cacheKey);
+
+      let revisionNumber =
+        localRevisionsByEntry &&
+        localRevisionsByEntry[localRevisionsByEntry.length - 1].revision
+          ? localRevisionsByEntry[localRevisionsByEntry.length - 1].revision
+          : REVISION_COUNTER;
+
+      revisionNumber = ++revisionNumber;
+
+      if (latestCacheValue && mergeStrategy) {
+        mergedEntityToCommit = mergeStrategy(
+          cacheKey,
+          {
+            entity: value,
+            revision: revisionNumber,
+            revisionContext: this.#revisionContext,
+          },
+          latestCacheValue,
+          this
+        );
+      } else {
+        mergedEntityToCommit = value;
+      }
+      const structuredClonedValue = structuredClone(
+        mergedEntityToCommit
+      ) as CacheKeyRegistry[Key];
+
+      const state = this.getCacheEntryState(cacheKey) || DEFAULT_ENTRY_STATE;
+
+      trasactionCacheEntries.push([cacheKey, structuredClonedValue, state]);
+
+      // Update saved revisions of the entity
+      const entityRevision = {
+        entity: mergedEntityToCommit as CacheKeyRegistry[Key],
+        revision: revisionNumber,
+        revisionContext: this.#revisionContext,
+      };
+
+      this.setLocalRevisionsByEntry(cacheKey, entityRevision);
+
+      this.#transactionOperations.updateSavedRevisions(
+        this.getLocalRevisions()
+      );
+
+      // Update revisions based on revision strategy
+      await this.#transactionOperations.applyRetentionPolicies(cacheKey, this);
+    }
+
+    // Call commit hook to apply custom retention policies before commit (if passed by cache options)
+    const commitCallback =
+      this.#originalCacheReference.getCacheOptions()?.hooks?.commit;
+    if (commitCallback) {
+      await commitCallback(this);
+    }
+
+    return {
+      entries: trasactionCacheEntries,
+    };
+  }
+
+  // assign transaction or cache level overriden merge strategy else use default
+  #getMergeStrategy(
+    transactionMergeStrategy?: EntityMergeStrategy<
+      CacheKeyRegistry,
+      Key,
+      $Debug,
+      UserExtensionData
+    >
+  ): EntityMergeStrategy<CacheKeyRegistry, Key, $Debug, UserExtensionData> {
+    const cacheWideMergeStrategy =
+      this.#originalCacheReference.getCacheOptions()?.hooks
+        ?.entitymergeStrategy as EntityMergeStrategy<
+        CacheKeyRegistry,
+        Key,
+        $Debug,
+        UserExtensionData
+      >;
+
+    return transactionMergeStrategy || cacheWideMergeStrategy;
+  }
+}
+
+// eslint-disable-next-line
+function structuredClone(x: any): any {
+  try {
+    return JSON.parse(JSON.stringify(x));
+  } catch (error) {
+    throw new Error(
+      'The cache value is not structured clonable use `save` with serializer'
+    );
+  }
+}


### PR DESCRIPTION
- The cache impl was in one large file. This PR splits it into separate files per class for easier readability
- Fixed minor logical patterns w.r.t CommittingCache and Revisions impl.