### PR TITLE
[athena] remove duplicate visited check in resolve

### DIFF
--- a/packages/athena/__tests__/client.test.ts
+++ b/packages/athena/__tests__/client.test.ts
@@ -241,6 +241,26 @@ describe('client', () => {
                 name: 'Foo',
               },
             },
+            {
+              id: '3',
+              __typename: 'Comment',
+              message: 'third comment',
+              author: {
+                id: '1',
+                __typename: 'Author',
+                name: 'Foo',
+              },
+            },
+            {
+              id: '4',
+              __typename: 'Comment',
+              message: 'fourth comment',
+              author: {
+                id: '1',
+                __typename: 'Author',
+                name: 'Foo',
+              },
+            },
           ],
         },
       };
@@ -271,6 +291,26 @@ describe('client', () => {
                 },
                 "id": "2",
                 "message": "second comment",
+              },
+              {
+                "__typename": "Comment",
+                "author": {
+                  "__typename": "Author",
+                  "id": "1",
+                  "name": "Foo",
+                },
+                "id": "3",
+                "message": "third comment",
+              },
+              {
+                "__typename": "Comment",
+                "author": {
+                  "__typename": "Author",
+                  "id": "1",
+                  "name": "Foo",
+                },
+                "id": "4",
+                "message": "fourth comment",
               },
             ],
             "id": "1",

--- a/packages/athena/src/signal-cache.ts
+++ b/packages/athena/src/signal-cache.ts
@@ -312,12 +312,6 @@ export class SignalCache {
         }
       }
 
-      // If this node has already been visited, we know it has already been fully traversed
-      // and don't need to continue
-      if (visited.has(value)) {
-        return false;
-      }
-
       // If we've made it here, it means that we've fully traversed all the elements in this path
       // and can mark this node as having been visited so we don't traverse it again
       exploring.delete(value);


### PR DESCRIPTION
Follow-on to https://github.com/data-eden/data-eden/pull/141 that removes the duplicated `visited` check logic