### PR TITLE
feature: add lazy query option

### DIFF
--- a/internal-packages/react-graphql-test-app/src/components/DisplayPerson.tsx
+++ b/internal-packages/react-graphql-test-app/src/components/DisplayPerson.tsx
@@ -9,6 +9,7 @@ import { PersonFieldsFragment } from './DisplayOwner.js';
 import DisplayCar from './DisplayCar';
 import DisplayPet from './DisplayPet';
 import { PetFieldsFragment } from '@aliased/DisplayPets';
+import DisplayPersonData from '../default-data/display-person-data.js';
 
 export interface Person {
   id: string;
@@ -71,9 +72,13 @@ const DisplayPets = ({ pets }: { pets: Array<Pet> }) => {
 };
 
 export default function DisplayPerson() {
-  const { loading, data } = useQuery(personQuery, {
-    id: '1',
-  });
+  const { loading, data } = useQuery(
+    personQuery,
+    {
+      id: '1',
+    },
+    { lazy: true, initialData: DisplayPersonData }
+  );
 
   const person = data?.person;
 

--- a/internal-packages/react-graphql-test-app/src/default-data/display-person-data.ts
+++ b/internal-packages/react-graphql-test-app/src/default-data/display-person-data.ts
@@ -1,0 +1,37 @@
+export default {
+  data: {
+    person: {
+      __typename: 'Person',
+      car: {
+        __typename: 'Car',
+        id: '1',
+        make: 'Ford',
+        model: 'Mustang',
+      },
+      pets: [
+        {
+          __typename: 'Pet',
+          id: '660d1bf5-f600-42d8-8c2a-c44210e7589b',
+          name: 'Hitch',
+          owner: {
+            __typename: 'Person',
+            id: '1',
+            name: 'Chris',
+          },
+        },
+        {
+          __typename: 'Pet',
+          id: 'db391623-3748-435c-bebe-7c193e42390e',
+          name: 'Dre',
+          owner: {
+            __typename: 'Person',
+            id: '1',
+            name: 'Chris',
+          },
+        },
+      ],
+      id: '1',
+      name: 'Chris',
+    },
+  },
+};

--- a/packages/react/src/setup-dependency-tracking.ts
+++ b/packages/react/src/setup-dependency-tracking.ts
@@ -1,0 +1,59 @@
+import type { WithSignal } from '@data-eden/athena';
+import { isSignalProxy, traverse, unwrap } from '@data-eden/athena';
+import { Reaction } from '@signalis/core';
+import type { MutableRefObject } from 'react';
+
+// Given a reactive entity, this function will traverse the entity and subscribe to all
+// the entities within it in order to make sure the component it was called in will react to
+// deeply nested changes
+export function setupDependencyTracking<Data extends object = object>(
+  cb: () => void,
+  reactionRef: MutableRefObject<Reaction | undefined>,
+  data?: Data
+) {
+  if (reactionRef.current) {
+    return;
+  }
+
+  if (data) {
+    const reaction = new Reaction(() => {
+      cb();
+    });
+
+    reaction.trap(() => {
+      let foundRoot = false;
+      let visited = new WeakSet<WithSignal<any>>();
+
+      traverse(data, (_key, value, _parent) => {
+        // In case we have a cycle, we don't want to blow everything up recursing infinitely
+        if (visited.has(value)) {
+          return false;
+        }
+
+        // DFS through the root object and if we find any other signals, we also subscribe
+        // to them so that deeply nested updates propagate through to React
+        if (isSignalProxy(value)) {
+          if (!foundRoot) {
+            foundRoot = true;
+          }
+          visited.add(value);
+          unwrap(value);
+          return true;
+        }
+
+        if (Array.isArray(value)) {
+          return true;
+        }
+
+        if (!foundRoot) {
+          return true;
+        }
+
+        return false;
+      });
+    });
+
+    reactionRef.current = reaction;
+    reaction.compute();
+  }
+}


### PR DESCRIPTION
This PR adds two new features to `useQuery`:
1. A `lazy` option that will stop `useQuery` from firing on component render (i.e. the user decides when to actually fire the query).
2. An `initialData` option that will populate the cache with whatever data is provided before firing the query (assuming the hook isn't in lazy mode).

These features serve two main purposes: cases where you've already got data in your app due to server rendering, and cases where you just need more control of when you'd like to fire a query.