### PR TITLE
feat: create mocker with basic support for fragments, queries and mutations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,4 +6,5 @@
 /internal-packages/react-graphql-test-app
 /internal-packages/graphql-test-server
 /packages/codegen/**/__graphql-project
+/packages/mocker/__tests__
 .rollup.cache

--- a/internal-packages/react-graphql-test-app/src/graphql/schema.graphql
+++ b/internal-packages/react-graphql-test-app/src/graphql/schema.graphql
@@ -1,3 +1,14 @@
+enum Breed {
+  SHEPARD
+  BULLDOG
+  POODLE
+  GERMAN_SHEPHERD
+  LABRADOR_RETRIEVER
+  GOLDEN_RETRIEVER
+}
+
+union Owner = Person | Company
+
 type Person {
   id: ID!
   name: String!
@@ -13,7 +24,12 @@ type Car {
   id: ID!
   make: String!
   model: String!
-  owner: Person!
+  owner: Owner!
+}
+
+type Company {
+  id: ID!
+  name: String!
 }
 
 input CarInput {
@@ -25,6 +41,7 @@ type Pet {
   id: ID!
   name: String!
   owner: Person!
+  breed: Breed!
 }
 
 input UpdatePetInput {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2300,6 +2300,10 @@
       "resolved": "packages/ember",
       "link": true
     },
+    "node_modules/@data-eden/mocker": {
+      "resolved": "packages/mocker",
+      "link": true
+    },
     "node_modules/@data-eden/network": {
       "resolved": "packages/network",
       "link": true
@@ -4050,6 +4054,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.2.tgz",
+      "integrity": "sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@gar/promisify": {
@@ -6543,9 +6562,10 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
+      "dev": true
     },
     "node_modules/@types/chai-as-promised": {
       "version": "7.1.5",
@@ -7304,8 +7324,9 @@
     },
     "node_modules/@vitest/expect": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.30.1.tgz",
+      "integrity": "sha512-c3kbEtN8XXJSeN81iDGq29bUzSjQhjES2WR3aColsS4lPGbivwLtas4DNUe0jD9gg/FYGIteqOenfU95EFituw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "0.30.1",
         "@vitest/utils": "0.30.1",
@@ -7314,8 +7335,9 @@
     },
     "node_modules/@vitest/runner": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.30.1.tgz",
+      "integrity": "sha512-W62kT/8i0TF1UBCNMRtRMOBWJKRnNyv9RrjIgdUryEe0wNpGZvvwPDLuzYdxvgSckzjp54DSpv1xUbv4BQ0qVA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/utils": "0.30.1",
         "concordance": "^5.0.4",
@@ -7325,8 +7347,9 @@
     },
     "node_modules/@vitest/runner/node_modules/p-limit": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -7339,8 +7362,9 @@
     },
     "node_modules/@vitest/runner/node_modules/yocto-queue": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       },
@@ -7350,8 +7374,9 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.30.1.tgz",
+      "integrity": "sha512-fJZqKrE99zo27uoZA/azgWyWbFvM1rw2APS05yB0JaLwUIg9aUtvvnBf4q7JWhEcAHmSwbrxKFgyBUga6tq9Tw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "magic-string": "^0.30.0",
         "pathe": "^1.1.0",
@@ -7360,8 +7385,9 @@
     },
     "node_modules/@vitest/snapshot/node_modules/magic-string": {
       "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.13"
       },
@@ -7371,16 +7397,18 @@
     },
     "node_modules/@vitest/spy": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.30.1.tgz",
+      "integrity": "sha512-YfJeIf37GvTZe04ZKxzJfnNNuNSmTEGnla2OdL60C8od16f3zOfv9q9K0nNii0NfjDJRt/CVN/POuY5/zTS+BA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyspy": "^2.1.0"
       }
     },
     "node_modules/@vitest/utils": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.30.1.tgz",
+      "integrity": "sha512-/c8Xv2zUVc+rnNt84QF0Y0zkfxnaGhp87K2dYJMLtLOIckPzuxLVzAtFCicGFdB4NeBHNzTRr1tNn7rCtQcWFA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "concordance": "^5.0.4",
         "loupe": "^2.3.6",
@@ -8094,8 +8122,9 @@
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -8762,8 +8791,9 @@
     },
     "node_modules/blueimp-md5": {
       "version": "2.19.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
+      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
+      "dev": true
     },
     "node_modules/body": {
       "version": "5.1.0",
@@ -10635,8 +10665,9 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -10851,8 +10882,9 @@
     },
     "node_modules/chai": {
       "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -10953,8 +10985,9 @@
     },
     "node_modules/check-error": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -11735,8 +11768,9 @@
     },
     "node_modules/concordance": {
       "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.4.tgz",
+      "integrity": "sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "date-time": "^3.1.0",
         "esutils": "^2.0.3",
@@ -12847,8 +12881,9 @@
     },
     "node_modules/date-time": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
+      "integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "time-zone": "^1.0.0"
       },
@@ -12920,8 +12955,9 @@
     },
     "node_modules/deep-eql": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -19981,8 +20017,9 @@
     },
     "node_modules/get-func-name": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -23110,8 +23147,9 @@
     },
     "node_modules/loupe": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.0"
       }
@@ -23364,8 +23402,9 @@
     },
     "node_modules/md5-hex": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
+      "integrity": "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "blueimp-md5": "^2.10.0"
       },
@@ -24219,14 +24258,15 @@
       }
     },
     "node_modules/mlly": {
-      "version": "1.2.0",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.3.0.tgz",
+      "integrity": "sha512-HT5mcgIQKkOrZecOjOX3DJorTikWXwsBfpcr/MGBkhfWcjiqvnaL/9ppxvIUXfjT6xt4DVIAsN9fMUz1ev4bIw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "acorn": "^8.8.2",
         "pathe": "^1.1.0",
-        "pkg-types": "^1.0.2",
-        "ufo": "^1.1.1"
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.1.2"
       }
     },
     "node_modules/morgan": {
@@ -25882,14 +25922,16 @@
       }
     },
     "node_modules/pathe": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
+      "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==",
+      "dev": true
     },
     "node_modules/pathval": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -26001,12 +26043,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.2.0",
-        "mlly": "^1.1.1",
+        "mlly": "^1.2.0",
         "pathe": "^1.1.0"
       }
     },
@@ -26880,8 +26923,9 @@
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -26893,8 +26937,9 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -26904,8 +26949,9 @@
     },
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/pretty-time": {
       "version": "1.1.0",
@@ -31833,8 +31879,9 @@
     },
     "node_modules/time-zone": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
+      "integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -31878,22 +31925,25 @@
       "license": "MIT"
     },
     "node_modules/tinybench": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
+      "integrity": "sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==",
+      "dev": true
     },
     "node_modules/tinypool": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.4.0.tgz",
+      "integrity": "sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tinyspy": {
-      "version": "2.1.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
+      "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -32181,8 +32231,9 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -32301,9 +32352,10 @@
       "license": "MIT"
     },
     "node_modules/ufo": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
+      "integrity": "sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==",
+      "dev": true
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
@@ -33025,8 +33077,9 @@
     },
     "node_modules/vite-node": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.30.1.tgz",
+      "integrity": "sha512-vTikpU/J7e6LU/8iM3dzBo8ZhEiKZEKRznEMm+mJh95XhWaPrJQraT/QsT2NWmuEf+zgAoMe64PKT7hfZ1Njmg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.4",
@@ -33047,8 +33100,9 @@
     },
     "node_modules/vitest": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.30.1.tgz",
+      "integrity": "sha512-y35WTrSTlTxfMLttgQk4rHcaDkbHQwDP++SNwPb+7H8yb13Q3cu2EixrtHzF27iZ8v0XCciSsLg00RkPAzB/aA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/chai": "^4.3.4",
         "@types/chai-subset": "^1.3.3",
@@ -33639,8 +33693,9 @@
     },
     "node_modules/well-known-symbols": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
+      "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=6"
       }
@@ -34832,6 +34887,18 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "packages/mocker": {
+      "name": "@data-eden/mocker",
+      "version": "0.9.0",
+      "license": "ISC",
+      "dependencies": {
+        "@faker-js/faker": "8.0.2",
+        "graphql": "^16.6.0"
+      },
+      "devDependencies": {
+        "vitest": "^0.30.1"
       }
     },
     "packages/network": {
@@ -36609,6 +36676,14 @@
         }
       }
     },
+    "@data-eden/mocker": {
+      "version": "file:packages/mocker",
+      "requires": {
+        "@faker-js/faker": "8.0.2",
+        "graphql": "^16.6.0",
+        "vitest": "^0.30.1"
+      }
+    },
     "@data-eden/network": {
       "version": "file:packages/network",
       "requires": {
@@ -37708,6 +37783,11 @@
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@faker-js/faker": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.2.tgz",
+      "integrity": "sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A=="
     },
     "@gar/promisify": {
       "version": "1.1.3",
@@ -39344,7 +39424,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.3.4",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
       "dev": true
     },
     "@types/chai-as-promised": {
@@ -39922,6 +40004,8 @@
     },
     "@vitest/expect": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.30.1.tgz",
+      "integrity": "sha512-c3kbEtN8XXJSeN81iDGq29bUzSjQhjES2WR3aColsS4lPGbivwLtas4DNUe0jD9gg/FYGIteqOenfU95EFituw==",
       "dev": true,
       "requires": {
         "@vitest/spy": "0.30.1",
@@ -39931,6 +40015,8 @@
     },
     "@vitest/runner": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.30.1.tgz",
+      "integrity": "sha512-W62kT/8i0TF1UBCNMRtRMOBWJKRnNyv9RrjIgdUryEe0wNpGZvvwPDLuzYdxvgSckzjp54DSpv1xUbv4BQ0qVA==",
       "dev": true,
       "requires": {
         "@vitest/utils": "0.30.1",
@@ -39941,6 +40027,8 @@
       "dependencies": {
         "p-limit": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+          "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
           "dev": true,
           "requires": {
             "yocto-queue": "^1.0.0"
@@ -39948,12 +40036,16 @@
         },
         "yocto-queue": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+          "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
           "dev": true
         }
       }
     },
     "@vitest/snapshot": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.30.1.tgz",
+      "integrity": "sha512-fJZqKrE99zo27uoZA/azgWyWbFvM1rw2APS05yB0JaLwUIg9aUtvvnBf4q7JWhEcAHmSwbrxKFgyBUga6tq9Tw==",
       "dev": true,
       "requires": {
         "magic-string": "^0.30.0",
@@ -39963,6 +40055,8 @@
       "dependencies": {
         "magic-string": {
           "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+          "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
           "dev": true,
           "requires": {
             "@jridgewell/sourcemap-codec": "^1.4.13"
@@ -39972,6 +40066,8 @@
     },
     "@vitest/spy": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.30.1.tgz",
+      "integrity": "sha512-YfJeIf37GvTZe04ZKxzJfnNNuNSmTEGnla2OdL60C8od16f3zOfv9q9K0nNii0NfjDJRt/CVN/POuY5/zTS+BA==",
       "dev": true,
       "requires": {
         "tinyspy": "^2.1.0"
@@ -39979,6 +40075,8 @@
     },
     "@vitest/utils": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.30.1.tgz",
+      "integrity": "sha512-/c8Xv2zUVc+rnNt84QF0Y0zkfxnaGhp87K2dYJMLtLOIckPzuxLVzAtFCicGFdB4NeBHNzTRr1tNn7rCtQcWFA==",
       "dev": true,
       "requires": {
         "concordance": "^5.0.4",
@@ -40464,6 +40562,8 @@
     },
     "assertion-error": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assign-symbols": {
@@ -40903,6 +41003,8 @@
     },
     "blueimp-md5": {
       "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
+      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
       "dev": true
     },
     "body": {
@@ -42324,6 +42426,8 @@
     },
     "cac": {
       "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true
     },
     "cache-base": {
@@ -42457,6 +42561,8 @@
     },
     "chai": {
       "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
@@ -42529,6 +42635,8 @@
     },
     "check-error": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
     "cheerio": {
@@ -43035,6 +43143,8 @@
     },
     "concordance": {
       "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.4.tgz",
+      "integrity": "sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==",
       "dev": true,
       "requires": {
         "date-time": "^3.1.0",
@@ -43731,6 +43841,8 @@
     },
     "date-time": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
+      "integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
       "dev": true,
       "requires": {
         "time-zone": "^1.0.0"
@@ -43772,6 +43884,8 @@
     },
     "deep-eql": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -48381,6 +48495,8 @@
     },
     "get-func-name": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
     "get-intrinsic": {
@@ -50337,6 +50453,8 @@
     },
     "loupe": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dev": true,
       "requires": {
         "get-func-name": "^2.0.0"
@@ -50512,6 +50630,8 @@
     },
     "md5-hex": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
+      "integrity": "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==",
       "dev": true,
       "requires": {
         "blueimp-md5": "^2.10.0"
@@ -50972,13 +51092,15 @@
       "version": "0.4.0"
     },
     "mlly": {
-      "version": "1.2.0",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.3.0.tgz",
+      "integrity": "sha512-HT5mcgIQKkOrZecOjOX3DJorTikWXwsBfpcr/MGBkhfWcjiqvnaL/9ppxvIUXfjT6xt4DVIAsN9fMUz1ev4bIw==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.2",
         "pathe": "^1.1.0",
-        "pkg-types": "^1.0.2",
-        "ufo": "^1.1.1"
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.1.2"
       }
     },
     "morgan": {
@@ -52003,11 +52125,15 @@
       "version": "4.0.0"
     },
     "pathe": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
+      "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==",
       "dev": true
     },
     "pathval": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "picocolors": {
@@ -52069,11 +52195,13 @@
       }
     },
     "pkg-types": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
       "dev": true,
       "requires": {
         "jsonc-parser": "^3.2.0",
-        "mlly": "^1.1.1",
+        "mlly": "^1.2.0",
         "pathe": "^1.1.0"
       }
     },
@@ -52522,6 +52650,8 @@
     },
     "pretty-format": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1",
@@ -52531,10 +52661,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
         },
         "react-is": {
           "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
           "dev": true
         }
       }
@@ -55771,6 +55905,8 @@
     },
     "time-zone": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
+      "integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
       "dev": true
     },
     "tiny-glob": {
@@ -55809,15 +55945,21 @@
       "version": "1.0.3"
     },
     "tinybench": {
-      "version": "2.4.0",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
+      "integrity": "sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==",
       "dev": true
     },
     "tinypool": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.4.0.tgz",
+      "integrity": "sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==",
       "dev": true
     },
     "tinyspy": {
-      "version": "2.1.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
+      "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
       "dev": true
     },
     "title-case": {
@@ -56013,6 +56155,8 @@
     },
     "type-detect": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-fest": {
@@ -56076,7 +56220,9 @@
       "dev": true
     },
     "ufo": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
+      "integrity": "sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==",
       "dev": true
     },
     "uglify-js": {
@@ -56490,6 +56636,8 @@
     },
     "vite-node": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.30.1.tgz",
+      "integrity": "sha512-vTikpU/J7e6LU/8iM3dzBo8ZhEiKZEKRznEMm+mJh95XhWaPrJQraT/QsT2NWmuEf+zgAoMe64PKT7hfZ1Njmg==",
       "dev": true,
       "requires": {
         "cac": "^6.7.14",
@@ -56502,6 +56650,8 @@
     },
     "vitest": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.30.1.tgz",
+      "integrity": "sha512-y35WTrSTlTxfMLttgQk4rHcaDkbHQwDP++SNwPb+7H8yb13Q3cu2EixrtHzF27iZ8v0XCciSsLg00RkPAzB/aA==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.3.4",
@@ -56869,6 +57019,8 @@
     },
     "well-known-symbols": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
+      "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
       "dev": true
     },
     "whatwg-url": {

--- a/packages/mocker/__tests__/mocker.test.ts
+++ b/packages/mocker/__tests__/mocker.test.ts
@@ -1,0 +1,316 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { describe, test, expect } from 'vitest';
+import { parse } from 'graphql';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { Mocker } from '@data-eden/mocker';
+
+const schema = readFileSync(
+  resolve(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'internal-packages/react-graphql-test-app/src/graphql/schema.graphql'
+  ),
+  'utf8'
+);
+
+describe('mocker', () => {
+  describe('fragments', () => {
+    test('fragment with default data', async () => {
+      const parsedFragment = parse(`
+        fragment car on Car {
+            id
+            make
+        }
+    `);
+      const fragmentDef = parsedFragment.definitions[0];
+
+      const mocker = new Mocker({ schema });
+      const result = await mocker.mock(fragmentDef, { id: 1234 });
+
+      expect(result).toMatchInlineSnapshot(`
+      {
+        "id": 1234,
+        "make": "whose nor",
+      }
+    `);
+    });
+
+    test('fragment with default data and fieldGenerator', async () => {
+      const parsedFragment = parse(`
+        fragment car on Car {
+            id
+            make
+        }
+    `);
+      const fragmentDef = parsedFragment.definitions[0];
+
+      const mocker = new Mocker({
+        schema,
+        fieldGenerators: {
+          Car: {
+            make() {
+              return 'Acura';
+            },
+          },
+        },
+      });
+      const result = await mocker.mock(fragmentDef, { id: 1234 });
+
+      expect(result).toMatchInlineSnapshot(`
+      {
+        "id": 1234,
+        "make": "Acura",
+      }
+    `);
+    });
+
+    test('fragment with enum values', async () => {
+      const parsedFragment = parse(`
+        fragment pet on Pet {
+            id
+            breed
+        }
+    `);
+      const fragmentDef = parsedFragment.definitions[0];
+
+      const mocker = new Mocker({
+        schema,
+      });
+      const result = await mocker.mock(fragmentDef, { id: 1234 });
+
+      expect(Object.keys(result)).toMatchInlineSnapshot(`
+        [
+          "id",
+          "breed",
+        ]
+      `);
+      expect(
+        [
+          'SHEPARD',
+          'BULLDOG',
+          'POODLE',
+          'GERMAN_SHEPHERD',
+          'LABRADOR_RETRIEVER',
+          'GOLDEN_RETRIEVER',
+        ].indexOf(result.breed) > -1
+      ).toBeTruthy();
+    });
+
+    test('fragment with union values', async () => {
+      const parsedFragment = parse(`
+        fragment car on Car {
+            id
+            make
+            owner {
+                ... on Person {
+                    id
+                    name
+                }
+                ... on Company {
+                    id
+                    name
+                }
+            }
+        }
+    `);
+      const fragmentDef = parsedFragment.definitions[0];
+
+      const mocker = new Mocker({
+        schema,
+      });
+      const result = await mocker.mock(fragmentDef, { id: 1234 });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "id": 1234,
+          "make": "whose nor",
+          "owner": {
+            "id": 1234,
+            "name": "tie",
+          },
+        }
+      `);
+    });
+
+    test('fragment with enum values (with provided enum value)', async () => {
+      const parsedFragment = parse(`
+        fragment pet on Pet {
+            id
+            breed
+        }
+    `);
+      const fragmentDef = parsedFragment.definitions[0];
+
+      const mocker = new Mocker({
+        schema,
+      });
+      const result = await mocker.mock(
+        fragmentDef,
+        { id: 1234, breed: 'SHEPARD' },
+        schema
+      );
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "breed": "SHEPARD",
+          "id": 1234,
+        }
+      `);
+    });
+
+    test("fragment with enum values (with provided enum value that doesn't match, this should throw)", async () => {
+      const parsedFragment = parse(`
+        fragment pet on Pet {
+            id
+            breed
+        }
+    `);
+      const fragmentDef = parsedFragment.definitions[0];
+
+      const mocker = new Mocker({
+        schema,
+      });
+
+      await expect(() =>
+        mocker.mock(fragmentDef, { id: 1234, breed: 'SHARK' })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        '"Trying to mock Breed with enum value SHARK does not match known enum values \\"[SHEPARD,BULLDOG,POODLE,GERMAN_SHEPHERD,LABRADOR_RETRIEVER,GOLDEN_RETRIEVER]\\""'
+      );
+    });
+
+    test('fragment with default data and fieldGenerator with array of values', async () => {
+      const parsedFragment = parse(`
+        fragment person on Person {
+            id
+            name
+            car {
+                id
+            }
+            pets {
+                id
+                name
+            }
+        }
+    `);
+      const fragmentDef = parsedFragment.definitions[0];
+
+      const mocker = new Mocker({
+        schema,
+        typeGenerators: {
+          ID() {
+            return 1234557;
+          },
+        },
+      });
+      const result = await mocker.mock(
+        fragmentDef,
+        { id: 1234, pets: [{}, { id: 99999, name: 'Bob' }] },
+        schema
+      );
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "car": {
+            "id": 1234,
+          },
+          "id": 1234,
+          "name": "whose nor",
+          "pets": [
+            {
+              "id": 1234557,
+              "name": "imperfect offensively thwack",
+            },
+            {
+              "id": 99999,
+              "name": "Bob",
+            },
+          ],
+        }
+      `);
+    });
+  });
+
+  describe('queries', () => {
+    test('should work with basic query (no overrides)', async () => {
+      const parsedQuery = parse(`
+        query {
+            car(id: 124) {
+                id
+                make
+                model
+            }
+        }
+    `);
+      const queryDef = parsedQuery.definitions[0];
+
+      const mocker = new Mocker({
+        schema,
+        typeGenerators: {
+          ID() {
+            return 1234557;
+          },
+        },
+        fieldGenerators: {
+          Car: {
+            make() {
+              return 'Italian Car';
+            },
+          },
+        },
+      });
+      // todo use the default value not the type generator
+      const result = await mocker.mock(queryDef, { id: 1234 });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "car": {
+            "id": 1234,
+            "make": "Italian Car",
+            "model": "whose nor",
+          },
+        }
+      `);
+    });
+  });
+
+  describe('mutations', () => {
+    test('should work with basic mutation (no overrides)', async () => {
+      const parsedQuery = parse(`
+        mutation {
+            createPet(input: {
+                name: "Bob"
+                personId: 1234
+            }) {
+                id
+                name
+            }
+        }
+    `);
+      const queryDef = parsedQuery.definitions[0];
+
+      const mocker = new Mocker({
+        schema,
+        typeGenerators: {
+          ID() {
+            return 1234557;
+          },
+        },
+      });
+      // todo use the default value not the type generator
+      const result = await mocker.mock(queryDef, { id: 1234 });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "createPet": {
+            "id": 1234,
+            "name": "whose nor",
+          },
+        }
+      `);
+    });
+  });
+});

--- a/packages/mocker/package.json
+++ b/packages/mocker/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@data-eden/mocker",
+  "version": "0.9.0",
+  "description": "",
+  "homepage": "https://github.com/data-eden/data-eden#readme",
+  "bugs": {
+    "url": "https://github.com/data-eden/data-eden/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/data-eden/data-eden.git"
+  },
+  "license": "ISC",
+  "author": "Gabriel Csapo <gabecsapo@gmail.com>",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/data-eden-mocker.js",
+      "require": "./dist/data-eden-mocker.umd.cjs"
+    }
+  },
+  "main": "./dist/data-eden-mocker.umd.cjs",
+  "module": "./dist/data-eden-mocker.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "vite build && tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "@faker-js/faker": "8.0.2",
+    "graphql": "^16.6.0"
+  },
+  "devDependencies": {
+    "vitest": "^0.30.1"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/mocker/src/index.ts
+++ b/packages/mocker/src/index.ts
@@ -1,0 +1,353 @@
+import type {
+  GraphQLSchema,
+  DefinitionNode,
+  GraphQLNamedType,
+  SelectionNode,
+  GraphQLType,
+  GraphQLEnumValue,
+} from 'graphql';
+import {
+  buildSchema,
+  GraphQLObjectType,
+  GraphQLList,
+  GraphQLEnumType,
+  GraphQLNonNull,
+  isNonNullType,
+  GraphQLUnionType,
+  Kind,
+} from 'graphql';
+import type { Faker } from '@faker-js/faker';
+import { faker as defaultFaker } from '@faker-js/faker';
+
+type JSONPrimitive = string | number | boolean | null;
+type JSONArray = JSONValue[];
+type JSONObject = { [key in string]: JSONValue | undefined };
+type JSONValue = JSONPrimitive | JSONArray | JSONObject;
+
+const defaultTypeGenerators: TypeGenerators = {
+  String(faker: Faker) {
+    return faker.word.words();
+  },
+  Int(faker: Faker) {
+    return faker.number.int();
+  },
+};
+
+type FieldGenerators = {
+  [className: string]: {
+    [key: string]: () => JSONValue;
+  };
+};
+
+type TypeGenerators = {
+  [key: string]: (faker: Faker) => JSONValue;
+};
+
+interface MockerOptions {
+  schema: string;
+  faker?: Faker;
+  typeGenerators?: TypeGenerators;
+  fieldGenerators?: FieldGenerators;
+}
+
+type FieldWithSelectionSet = SelectionNode & {
+  selectionSet: {
+    selections: readonly SelectionNode[];
+  };
+};
+
+function assertHasSelectionSet(
+  field: SelectionNode
+): asserts field is FieldWithSelectionSet {
+  if (field.kind !== Kind.FRAGMENT_SPREAD && !field.selectionSet) {
+    const fieldName =
+      (field.kind === Kind.INLINE_FRAGMENT
+        ? field?.typeCondition?.name.value
+        : field.name.value) ?? '"Can not resolve the name"';
+    throw new Error(`Field ${fieldName} does not have a selection set.`);
+  }
+}
+
+export class Mocker {
+  private faker: Faker;
+  private fieldGenerators: FieldGenerators;
+  private typeGenerators: TypeGenerators;
+  private schema: GraphQLSchema;
+
+  constructor({
+    schema,
+    faker,
+    typeGenerators,
+    fieldGenerators,
+  }: MockerOptions) {
+    if (!schema) {
+      throw new Error('Schema is required');
+    }
+
+    this.faker = faker ?? defaultFaker;
+    this.fieldGenerators = fieldGenerators || {};
+    this.typeGenerators = {
+      ...defaultTypeGenerators,
+      ...(typeGenerators || {}),
+    };
+    this.schema = buildSchema(schema);
+
+    // we need to set the seed on the faker instance
+    this.faker.seed(2345678);
+  }
+
+  async mock(definition: DefinitionNode, mockData: JSONObject) {
+    let typeName: string;
+    let selections: readonly SelectionNode[];
+
+    if (definition.kind === 'FragmentDefinition') {
+      typeName = definition.typeCondition.name.value;
+      selections = definition.selectionSet.selections;
+    } else if (
+      definition.kind === 'OperationDefinition' &&
+      definition.operation === 'query'
+    ) {
+      typeName = 'Query';
+      selections = definition.selectionSet.selections;
+    } else if (
+      definition.kind === 'OperationDefinition' &&
+      definition.operation === 'mutation'
+    ) {
+      typeName = 'Mutation';
+      selections = definition.selectionSet.selections;
+    } else {
+      throw new Error(`Unsupported definition kind "${definition.kind}"`);
+    }
+
+    const type = this.schema.getType(typeName) as GraphQLNamedType;
+
+    if (!type) {
+      throw new Error(`Type ${typeName} not found in the schema`);
+    }
+
+    return this.generateMockDataForFields(selections, type, mockData);
+  }
+
+  private generateMockDataForFields(
+    fields: readonly SelectionNode[],
+    type: GraphQLNamedType,
+    mockData: JSONObject | undefined
+  ): JSONObject {
+    let result: JSONObject = {};
+
+    fields.forEach((field) => {
+      if (field.kind === 'InlineFragment') {
+        // Handle inline fragments
+        if (!field.typeCondition) {
+          throw new Error(
+            'Could not handle a case where inline fragment typeCondition was undefined'
+          );
+        }
+
+        const fragmentType = field.typeCondition.name.value;
+        result = {
+          ...result,
+          ...this.generateMockDataForFields(
+            field.selectionSet.selections,
+            this.schema.getType(fragmentType) as GraphQLNamedType,
+            mockData
+          ),
+        };
+      } else if (field.kind === 'FragmentSpread') {
+        throw new Error(
+          'Fragment spreads are not supported, please resolve all fragments spreads before trying to mock.'
+        );
+      } else {
+        const fieldName = field.name.value;
+
+        if (
+          !type ||
+          !('getFields' in type) ||
+          !type.getFields ||
+          !type.getFields()[fieldName]
+        ) {
+          throw new Error(
+            `Field ${fieldName} does not exist in the schema for type ${type?.name}`
+          );
+        }
+
+        let fieldType = type.getFields()[fieldName].type;
+
+        // If it's a NonNull type, unwrap it
+        if (fieldType instanceof GraphQLNonNull) {
+          fieldType = fieldType.ofType;
+        }
+
+        // Handle list types (arrays)
+        if (fieldType instanceof GraphQLList) {
+          let elementType: GraphQLType = fieldType.ofType;
+
+          // If it's a NonNull type, unwrap it again to get the actual element type
+          if (elementType instanceof GraphQLNonNull) {
+            elementType = elementType.ofType;
+          }
+
+          // If no mock data is provided for the list, create an empty array
+          if (!mockData || !mockData[fieldName]) {
+            result[fieldName] = [];
+          } else {
+            // Check if the element is an object type, and if so, recursively generate the mock data
+            if (elementType instanceof GraphQLObjectType) {
+              result[fieldName] = (mockData[fieldName] as JSONArray).map(
+                (item) => {
+                  assertHasSelectionSet(field);
+
+                  return this.generateMockDataForFields(
+                    field.selectionSet.selections,
+                    elementType as GraphQLObjectType,
+                    item as JSONObject
+                  );
+                }
+              );
+            } else {
+              // Handle scalar type arrays (e.g., [Int], [String])
+              result[fieldName] = (mockData[fieldName] as JSONArray).map(
+                (item) =>
+                  this.generateMockDataForType(
+                    type.name,
+                    fieldName,
+                    elementType,
+                    item
+                  )
+              );
+            }
+          }
+        } else if (fieldType instanceof GraphQLObjectType) {
+          // Recursively handle object types
+          assertHasSelectionSet(field);
+
+          result[fieldName] = this.generateMockDataForFields(
+            field.selectionSet.selections,
+            fieldType,
+            mockData
+          );
+        } else if (fieldType instanceof GraphQLEnumType) {
+          // Handle enum types
+          const enumValues = fieldType.getValues();
+          result[fieldName] = this.generateMockDataForEnum(
+            fieldType.name,
+            enumValues,
+            mockData && mockData[fieldName]
+          );
+        } else if (fieldType instanceof GraphQLUnionType) {
+          // Handle union types
+          const possibleTypes = fieldType.getTypes();
+
+          // Check if mockData is provided for the union field
+          if (mockData && mockData[fieldName]) {
+            const mockDataUnionType = (mockData[fieldName] as JSONObject)
+              .__typename;
+            const matchingType = possibleTypes.find(
+              (type) => type.name === mockDataUnionType
+            );
+            if (matchingType) {
+              assertHasSelectionSet(field);
+              result[fieldName] = this.generateMockDataForFields(
+                field.selectionSet.selections,
+                matchingType,
+                mockData[fieldName] as JSONObject
+              );
+              return;
+            }
+          }
+
+          const randomIndex = Math.floor(Math.random() * possibleTypes.length);
+          const randomType = possibleTypes[randomIndex];
+          assertHasSelectionSet(field);
+          result[fieldName] = this.generateMockDataForFields(
+            field.selectionSet.selections,
+            randomType,
+            mockData
+          );
+        } else {
+          // Generate mock data for scalar fields
+          result[fieldName] = this.generateMockDataForType(
+            type.name,
+            fieldName,
+            fieldType,
+            mockData && mockData[fieldName]
+          );
+        }
+      }
+    });
+
+    return result;
+  }
+
+  private generateMockDataForEnum(
+    fieldName: string,
+    enumValues: readonly GraphQLEnumValue[],
+    providedValue: JSONValue | undefined
+  ): string {
+    const values = enumValues.map((enumValue) => enumValue.name);
+    if (providedValue) {
+      if (typeof providedValue !== 'string') {
+        throw new Error(
+          `${JSON.stringify(
+            providedValue
+          )} is not a valid ENUM value as it can only be a string`
+        );
+      }
+
+      if (values.indexOf(providedValue) > -1) {
+        return providedValue;
+      } else {
+        throw new Error(
+          `Trying to mock ${fieldName} with enum value ${providedValue} does not match known enum values "[${values.join(
+            ','
+          )}]"`
+        );
+      }
+    }
+    const randomIndex = Math.floor(Math.random() * values.length);
+    return values[randomIndex];
+  }
+
+  private generateMockDataForType(
+    className: string,
+    fieldName: string,
+    type: GraphQLType | GraphQLNonNull<GraphQLType>,
+    inputMockData: JSONValue | undefined
+  ): JSONValue {
+    // Check if this is a NonNull type
+    if (isNonNullType(type) && type.ofType) {
+      return this.generateMockDataForType(
+        className,
+        fieldName,
+        type.ofType,
+        inputMockData
+      );
+    }
+
+    // Use input mock data if provided
+    if (inputMockData !== undefined) {
+      return inputMockData;
+    }
+
+    if (
+      this.fieldGenerators[className] &&
+      this.fieldGenerators[className][fieldName]
+    ) {
+      return this.fieldGenerators[className][fieldName]();
+    }
+
+    if (!isNonNullType(type) && this.typeGenerators[type.name]) {
+      return this.typeGenerators[type.name](this.faker);
+    } else {
+      if (isNonNullType(type)) {
+        throw new Error(
+          `Value generation could not be done for type ${type.ofType.toString()}. Please provide an override to typeGenerators.`
+        );
+      } else {
+        throw new Error(
+          `Value generation could not be done for type ${type.name}. Please provide an override to typeGenerators.`
+        );
+      }
+    }
+  }
+}

--- a/packages/mocker/tsconfig.build.json
+++ b/packages/mocker/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/mocker/tsconfig.json
+++ b/packages/mocker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "noEmitOnError": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/mocker/vite.config.ts
+++ b/packages/mocker/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: '@data-eden/mocker',
+      fileName: 'data-eden-mocker',
+    },
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,9 @@
       "path": "./packages/codegen"
     },
     {
+      "path": "./packages/mocker"
+    },
+    {
       "path": "./packages/network/__tests__/"
     },
     {


### PR DESCRIPTION
Right now it requires passing a manually parsed query, the next pass on this will be hooking this up with codegen and specifically having codegen produce a rollup plugin to provide a zero configuration option for codegen.