### PR TITLE
feat: enable mocker to properly return typed data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6384,32 +6384,6 @@
       "version": "3.0.4",
       "license": "MIT"
     },
-    "node_modules/@rollup/plugin-babel": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.0.3.tgz",
-      "integrity": "sha512-fKImZKppa1A/gX73eg4JGo+8kQr/q1HBQaCGKECZ0v4YBBv3lFqi14+7xyApECzvkLTHCifx+7ntcrvtBIRcpg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.18.6",
-        "@rollup/pluginutils": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "@types/babel__core": "^7.1.9",
-        "rollup": "^1.20.0||^2.0.0||^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/babel__core": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.0.tgz",
@@ -34155,7 +34129,6 @@
       "devDependencies": {
         "@babel/preset-typescript": "^7.22.5",
         "@data-eden/codegen": "^0.10.0",
-        "@rollup/plugin-babel": "^6.0.3",
         "vitest": "^0.30.1"
       }
     },
@@ -36029,7 +36002,6 @@
         "@babel/preset-typescript": "^7.22.5",
         "@data-eden/codegen": "^0.10.0",
         "@faker-js/faker": "8.0.2",
-        "@rollup/plugin-babel": "^6.0.3",
         "graphql": "^16.6.0",
         "vitest": "^0.30.1"
       }
@@ -38656,16 +38628,6 @@
     },
     "@repeaterjs/repeater": {
       "version": "3.0.4"
-    },
-    "@rollup/plugin-babel": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.0.3.tgz",
-      "integrity": "sha512-fKImZKppa1A/gX73eg4JGo+8kQr/q1HBQaCGKECZ0v4YBBv3lFqi14+7xyApECzvkLTHCifx+7ntcrvtBIRcpg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.18.6",
-        "@rollup/pluginutils": "^5.0.1"
-      }
     },
     "@rollup/plugin-commonjs": {
       "version": "25.0.0",

--- a/packages/codegen/src/rollup-plugin.ts
+++ b/packages/codegen/src/rollup-plugin.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from 'rollup';
-import { transformFileSync } from '@babel/core';
+import { transformSync } from '@babel/core';
 
 import { babelPlugin } from './babel-plugin.js';
 import { athenaCodegen } from './codegen.js';
@@ -15,8 +15,9 @@ export function rollupPlugin(options: CodegenConfig): Plugin {
 
     transform(code, id) {
       if (code.indexOf('@data-eden/codegen/gql') > -1) {
-        const result = transformFileSync(id, {
+        const result = transformSync(code, {
           plugins: [babelPlugin],
+          filename: id,
         });
 
         return result?.code;

--- a/packages/mocker/__tests__/mocker.test.ts
+++ b/packages/mocker/__tests__/mocker.test.ts
@@ -2,9 +2,19 @@ import { describe, test, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-import { Mocker } from '@data-eden/mocker';
-
 import { gql } from '@data-eden/codegen/gql';
+
+import { Mocker } from '@data-eden/mocker';
+import {
+  CarOneFragment,
+  CarThreeFragment,
+  CarTwoFragment,
+  CreateOnePetMutation,
+  PersonOneFragment,
+  PetOneFragment,
+  PetThreeFragment,
+  PetTwoFragment,
+} from './__generated/mocker.test.graphql';
 
 const schema = readFileSync(
   resolve(
@@ -20,7 +30,7 @@ const schema = readFileSync(
 describe('mocker', () => {
   describe('fragments', () => {
     test('fragment with default data', async () => {
-      const carOneFragment = gql`
+      const carOneFragment = gql<CarOneFragment>`
         fragment carOne on Car {
           id
           make
@@ -34,7 +44,7 @@ describe('mocker', () => {
     });
 
     test('fragment with default data and fieldGenerator', async () => {
-      const carTwoFragment = gql`
+      const carTwoFragment = gql<CarTwoFragment>`
         fragment carTwo on Car {
           id
           make
@@ -51,13 +61,15 @@ describe('mocker', () => {
           },
         },
       });
-      const result = await mocker.mock(carTwoFragment, { id: 1234 });
+      const result = await mocker.mock(carTwoFragment, {
+        id: 1234,
+      });
 
       expect(result).toMatchSnapshot();
     });
 
     test('fragment with enum values', async () => {
-      const petOneFragment = gql`
+      const petOneFragment = gql<PetOneFragment>`
         fragment petOne on Pet {
           id
           breed
@@ -90,7 +102,7 @@ describe('mocker', () => {
     });
 
     test('fragment with union values', async () => {
-      const carThreeFragment = gql`
+      const carThreeFragment = gql<CarThreeFragment>`
         fragment carThree on Car {
           id
           make
@@ -116,7 +128,7 @@ describe('mocker', () => {
     });
 
     test('fragment with enum values (with provided enum value)', async () => {
-      const petTwoFragment = gql`
+      const petTwoFragment = gql<PetTwoFragment>`
         fragment petTwo on Pet {
           id
           breed
@@ -135,7 +147,7 @@ describe('mocker', () => {
     });
 
     test("fragment with enum values (with provided enum value that doesn't match, this should throw)", async () => {
-      const petThreeFragment = gql`
+      const petThreeFragment = gql<PetThreeFragment>`
         fragment petThree on Pet {
           id
           breed
@@ -152,7 +164,7 @@ describe('mocker', () => {
     });
 
     test('fragment with default data and fieldGenerator with array of values', async () => {
-      const personOneFragment = gql`
+      const personOneFragment = gql<PersonOneFragment>`
         fragment personOne on Person {
           id
           name
@@ -185,7 +197,7 @@ describe('mocker', () => {
 
   describe('queries', () => {
     test('should work with basic query (no overrides)', async () => {
-      const carOneQuery = gql`
+      const carOneQuery = gql<CarOneFragment>`
         query carOne {
           car(id: 124) {
             id
@@ -218,7 +230,7 @@ describe('mocker', () => {
 
   describe('mutations', () => {
     test('should work with basic mutation (no overrides)', async () => {
-      const createOnePetMutation = gql`
+      const createOnePetMutation = gql<CreateOnePetMutation>`
         mutation createOnePet {
           createPet(input: { name: "Bob", personId: 1234 }) {
             id

--- a/packages/mocker/package.json
+++ b/packages/mocker/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "vite build && tsc -p tsconfig.build.json",
     "dev": "tsc --watch",
-    "test": "vitest run --reporter=verbose"
+    "test": "vitest run"
   },
   "dependencies": {
     "@faker-js/faker": "8.0.2",
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.22.5",
     "@data-eden/codegen": "^0.10.0",
-    "@rollup/plugin-babel": "^6.0.3",
     "vitest": "^0.30.1"
   },
   "volta": {

--- a/packages/mocker/vitest.config.ts
+++ b/packages/mocker/vitest.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import { resolve } from 'node:path';
 
-import { babel } from '@rollup/plugin-babel';
 import { rollupPlugin } from '@data-eden/codegen';
 
 export default defineConfig({
@@ -15,9 +14,6 @@ export default defineConfig({
       extension: '.graphql.ts',
       disableSchemaTypesGeneration: false,
       production: false,
-    }),
-    babel({
-      presets: ['@babel/preset-typescript'],
     }),
   ],
   test: {


### PR DESCRIPTION
properly returns the value of the typeddocumentnode as data to ensure type checking works correctly

> This also fixes the rollup plugin to avoid reading from disk and getting the raw value and instead just parsing the code given to the plugin which helps avoid typescript problems that we solved with rollup plugin babel

## Before

<img width="676" alt="Screenshot 2023-06-14 at 2 49 26 PM" src="https://github.com/data-eden/data-eden/assets/1854811/a8a0bc83-a703-483f-aca2-9a092f015a72">

## After

<img width="656" alt="Screenshot 2023-06-14 at 2 49 42 PM" src="https://github.com/data-eden/data-eden/assets/1854811/ade042a5-60f3-4b62-84c7-1bda6d52aff6">

