### PR TITLE
feat: support non-managed entities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      - run: npm run build
       - run: npm run test:workspaces

--- a/internal-packages/react-graphql-test-app/vite.config.ts
+++ b/internal-packages/react-graphql-test-app/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import graphql from '@rollup/plugin-graphql';
-import { rollupPlugin } from '../../packages/codegen/src/index';
+import { rollupPlugin } from '@data-eden/codegen';
 
 import { resolve } from 'node:path';
 import { readFileSync } from 'node:fs';

--- a/package-lock.json
+++ b/package-lock.json
@@ -33621,6 +33621,9 @@
         "lodash-es": "^4.17.21"
       },
       "devDependencies": {
+        "@data-eden/codegen": "0.13.2",
+        "@data-eden/mocker": "0.13.2",
+        "@data-eden/shared-test-utilities": "0.13.2",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@signalis/core": "^0.1.0",
         "@types/lodash-es": "^4.17.6",
@@ -33629,6 +33632,60 @@
       },
       "peerDependencies": {
         "graphql": "^16.6.0"
+      }
+    },
+    "packages/athena/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/athena/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "packages/athena/node_modules/globby": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.0.tgz",
+      "integrity": "sha512-jWsQfayf13NvqKUIL3Ta+CIqMnvlaIDFveWE/dpOZ9+3AMEJozsxDvKA02zync9UuvOM8rOXzsD5GqKP4OnWPQ==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/athena/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/athena/node_modules/type-fest": {
@@ -35611,6 +35668,9 @@
       "version": "file:packages/athena",
       "requires": {
         "@data-eden/cache": "^0.13.2",
+        "@data-eden/codegen": "0.13.2",
+        "@data-eden/mocker": "0.13.2",
+        "@data-eden/shared-test-utilities": "0.13.2",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@signalis/core": "^0.1.0",
         "@types/lodash-es": "^4.17.6",
@@ -35620,6 +35680,39 @@
         "type-fest": "^3.5.6"
       },
       "dependencies": {
+        "commander": {
+          "version": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "globby": {
+          "version": "https://registry.npmjs.org/globby/-/globby-13.2.0.tgz",
+          "integrity": "sha512-jWsQfayf13NvqKUIL3Ta+CIqMnvlaIDFveWE/dpOZ9+3AMEJozsxDvKA02zync9UuvOM8rOXzsD5GqKP4OnWPQ==",
+          "dev": true,
+          "requires": {
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.11",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^4.0.0"
+          }
+        },
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+          "dev": true
+        },
         "type-fest": {
           "version": "3.8.0",
           "dev": true

--- a/packages/athena/.gitignore
+++ b/packages/athena/.gitignore
@@ -1,0 +1,1 @@
+__tests__/__generated

--- a/packages/athena/package.json
+++ b/packages/athena/package.json
@@ -29,6 +29,9 @@
     "lodash-es": "^4.17.21"
   },
   "devDependencies": {
+    "@data-eden/codegen": "0.13.2",
+    "@data-eden/mocker": "0.13.2",
+    "@data-eden/shared-test-utilities": "0.13.2",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@signalis/core": "^0.1.0",
     "@types/lodash-es": "^4.17.6",

--- a/packages/athena/src/client.ts
+++ b/packages/athena/src/client.ts
@@ -199,6 +199,11 @@ export class AthenaClient {
       for (const { parent, prop, entity } of parsedEntities) {
         const key = this.getCacheKey(entity, parent);
 
+        if (!key) {
+          // if we don't have a key it is not cacheable and must be cached based on the parent
+          continue;
+        }
+
         // replace the entity object with the key we're using to store it in the cache so that we can
         // later replace the key with the reactive entity
         // e.g. { pet: { id: 1, name: hitch }} -> { pet: 'pet:1' }

--- a/packages/athena/src/types.ts
+++ b/packages/athena/src/types.ts
@@ -66,4 +66,4 @@ export interface ParsedEntity {
   prop: string | number | Array<string | number>;
 }
 
-export type IdFetcher<T = any> = (v: T, parent: T) => string;
+export type IdFetcher<T = any> = (v: T, parent: T) => string | undefined;

--- a/packages/athena/vitest.config.ts
+++ b/packages/athena/vitest.config.ts
@@ -1,13 +1,35 @@
 import { defineConfig } from 'vitest/config';
 import { resolve } from 'node:path';
+import { rollupPlugin } from '@data-eden/codegen';
 
 export default defineConfig({
+  plugins: [
+    rollupPlugin({
+      baseDir: resolve(__dirname, '__tests__'),
+      schemaPath: resolve(
+        __dirname,
+        '..',
+        '..',
+        'internal-packages',
+        'react-graphql-test-app',
+        'src',
+        'graphql',
+        'schema.graphql'
+      ),
+      documents: ['**/*.test.ts'],
+      extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
+      production: false,
+    }),
+  ],
   test: {
     testTimeout: 10_000,
+    include: ['__tests__/**/*.test.ts'],
   },
   resolve: {
     alias: {
       '@data-eden/athena': resolve(__dirname, './src'),
+      '@data-eden/mocker': resolve(__dirname, '../mocker/src'),
     },
   },
 });


### PR DESCRIPTION
- allow getCacheKey to return undefined value
- allow entities with no cache key handle unmanaged entities
- utilizes @data-eden/mocker in tests
- writes new tests for client query (we should write more)