### PR TITLE
bug: integration into downstreams exposes type issue in cache

### DIFF
--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -635,8 +635,8 @@ function deepMerge(
 }
 
 function resolveConflict(
-  target: Record<string, object | string | number>,
-  source: Record<string, object | string | number>,
+  target: Record<string, object | string | number | undefined>,
+  source: Record<string, object | string | number | undefined>,
   property: string
 ): CacheKeyValue {
   return deepMerge(

--- a/packages/cache/types/api.d.ts
+++ b/packages/cache/types/api.d.ts
@@ -262,7 +262,7 @@ export interface CacheEntryState<UserExtensionData = unknown> {
 }
 
 export type CacheKeyValue =
-  | Record<string, object | string | number>
+  | Record<string, object | string | number | undefined>
   | string
   | number;
 


### PR DESCRIPTION
<img width="569" alt="Screenshot 2023-06-23 at 11 47 22 AM" src="https://github.com/data-eden/data-eden/assets/1854811/06cd9a23-fb87-4a90-a1d0-2427f1be831c">

same version of typescript but exposes type issue