### PR TITLE
feat: handle unmanaged objects with synthetic keys

### DIFF
--- a/packages/athena/__tests__/signal-cache.test.ts
+++ b/packages/athena/__tests__/signal-cache.test.ts
@@ -126,6 +126,7 @@ describe('signal cache', () => {
         (v) => createSignal(v, false),
         undefined,
         undefined,
+        undefined,
         250
       );
       cache.storeOperation(

--- a/packages/athena/src/types.ts
+++ b/packages/athena/src/types.ts
@@ -66,4 +66,8 @@ export interface ParsedEntity {
   prop: string | number | Array<string | number>;
 }
 
-export type IdFetcher<T = any> = (v: T, parent: T) => string | undefined;
+export type IdFetcher<T = any> = (v: T) => string | undefined;
+export type SyntheticIdFetcher = (
+  parsedEntity: ParsedEntity,
+  getCacheKey: IdFetcher
+) => string;


### PR DESCRIPTION
- creates a synthetic key hook for unmanaged entities via getCacheKey (these are entities that you know will change data but don't want to key off of the data itself but potentially on the path)
- adds tests
- removes code where we had objects that were not signals nested
- fixes a bug where parentArray was not terminating so nested keys would be keyed in parentArray 