### PR TITLE
feat: support union fragments mocking top level

### DIFF
--- a/packages/mocker/__tests__/__snapshots__/mocker.test.ts.snap
+++ b/packages/mocker/__tests__/__snapshots__/mocker.test.ts.snap
@@ -17,7 +17,7 @@ exports[`mocker > fragments > fragment with default data and fieldGenerator 1`] 
 exports[`mocker > fragments > fragment with default data and fieldGenerator with array of values 1`] = `
 {
   "car": {
-    "id": 1234,
+    "id": 1234557,
   },
   "id": 1234,
   "name": "whose nor",
@@ -43,22 +43,11 @@ exports[`mocker > fragments > fragment with enum values (with provided enum valu
 }
 `;
 
-exports[`mocker > fragments > fragment with union values 1`] = `
-{
-  "id": 1234,
-  "make": "whose nor",
-  "owner": {
-    "id": 1234,
-    "name": "tie",
-  },
-}
-`;
-
 exports[`mocker > mutations > should work with basic mutation (no overrides) 1`] = `
 {
   "createPet": {
     "__typename": "Pet",
-    "id": 1234,
+    "id": 1234557,
     "name": "whose nor",
   },
 }
@@ -68,7 +57,7 @@ exports[`mocker > queries > should work with basic query (no overrides) 1`] = `
 {
   "car": {
     "__typename": "Car",
-    "id": 1234,
+    "id": 1234557,
     "make": "Italian Car",
     "model": "whose nor",
   },

--- a/packages/mocker/vite.config.ts
+++ b/packages/mocker/vite.config.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path';
 
 export default defineConfig({
   build: {
+    sourcemap: true,
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
       name: '@data-eden/mocker',


### PR DESCRIPTION
previously we did not support mocking top level fragment types that were union values

```graphql
fragment owner on Owner {
  ... on Person {
    __typename
    id
    name
    car {
      __typename
      id
      make
    }
  }
  ... on Company {
    __typename
    id
    name
  }
}
```

with this change we can.

This also fixes an issue where we were not properly matching types and always projecting all types for all possible union types.