### PR TITLE
feat: thread types through to get autcomplete for mockData

### DIFF
--- a/packages/mocker/__tests__/__snapshots__/mocker.test.ts.snap
+++ b/packages/mocker/__tests__/__snapshots__/mocker.test.ts.snap
@@ -9,7 +9,7 @@ exports[`mocker > fragments > fragment with default data 1`] = `
 
 exports[`mocker > fragments > fragment with default data and fieldGenerator 1`] = `
 {
-  "id": 1234,
+  "id": "1234",
   "make": "Acura",
 }
 `;
@@ -17,17 +17,17 @@ exports[`mocker > fragments > fragment with default data and fieldGenerator 1`] 
 exports[`mocker > fragments > fragment with default data and fieldGenerator with array of values 1`] = `
 {
   "car": {
-    "id": 1234557,
+    "id": "1234557",
   },
-  "id": 1234,
+  "id": "1234",
   "name": "whose nor",
   "pets": [
     {
-      "id": 1234557,
+      "id": "1234557",
       "name": "imperfect offensively thwack",
     },
     {
-      "id": 99999,
+      "id": "99999",
       "name": "Bob",
     },
   ],
@@ -39,7 +39,7 @@ exports[`mocker > fragments > fragment with enum values (with provided enum valu
 exports[`mocker > fragments > fragment with enum values (with provided enum value) 1`] = `
 {
   "breed": "SHEPARD",
-  "id": 1234,
+  "id": "1234",
 }
 `;
 
@@ -47,7 +47,7 @@ exports[`mocker > mutations > should work with basic mutation (no overrides) 1`]
 {
   "createPet": {
     "__typename": "Pet",
-    "id": 1234557,
+    "id": "1234",
     "name": "whose nor",
   },
 }
@@ -57,7 +57,7 @@ exports[`mocker > queries > should work with basic query (no overrides) 1`] = `
 {
   "car": {
     "__typename": "Car",
-    "id": 1234557,
+    "id": "1234557",
     "make": "Italian Car",
     "model": "whose nor",
   },

--- a/packages/mocker/__tests__/mocker.test.ts
+++ b/packages/mocker/__tests__/mocker.test.ts
@@ -17,6 +17,7 @@ import {
   PetThreeFragment,
   PetTwoFragment,
 } from './__generated/mocker.test.graphql';
+import { Breed } from '../../../internal-packages/react-graphql-test-app/src/graphql/schema.graphql.js';
 
 const schema = readFileSync(
   resolve(
@@ -64,7 +65,7 @@ describe('mocker', () => {
         },
       });
       const result = await mocker.mock(carTwoFragment, {
-        id: 1234,
+        id: '1234',
       });
 
       expect(result).toMatchSnapshot();
@@ -133,11 +134,11 @@ describe('mocker', () => {
         schema,
         typeGenerators: {
           ID() {
-            return 1234;
+            return '1234';
           },
         },
       });
-      const result = await mocker.mock(carThreeFragment, { id: 1234 });
+      const result = await mocker.mock(carThreeFragment, { id: '1234' });
 
       // we know that this is going to be a random result because we are picking a random resolution everytime
       // so the expects below are handling both cases for whatever union we mock out
@@ -187,31 +188,31 @@ describe('mocker', () => {
         schema,
         typeGenerators: {
           ID() {
-            return 123;
+            return '123';
           },
         },
       });
 
       const result = await mocker.mock(carFourFragment, {
-        id: 1234,
+        id: '1234',
         owner: {
           __typename: 'Person',
-          id: 123,
+          id: '123',
           name: 'Bob',
         },
       });
 
       expect(result).toEqual({
         __typename: 'Car',
-        id: 1234,
+        id: '1234',
         make: 'whose nor',
         owner: {
           __typename: 'Person',
-          id: 123,
+          id: '123',
           name: 'Bob',
           car: {
             __typename: 'Car',
-            id: 123,
+            id: '123',
             make: 'imperfect offensively thwack',
           },
         },
@@ -243,13 +244,13 @@ describe('mocker', () => {
         schema,
         typeGenerators: {
           ID: () => {
-            return 123;
+            return '123';
           },
         },
       });
       const result = await mocker.mock(ownerFragment, {
         __typename: 'Person',
-        id: 123,
+        id: '123',
         name: 'Bob',
         car: {
           make: 'Accura',
@@ -258,11 +259,11 @@ describe('mocker', () => {
 
       expect(result).toEqual({
         __typename: 'Person',
-        id: 123,
+        id: '123',
         name: 'Bob',
         car: {
           __typename: 'Car',
-          id: 123,
+          id: '123',
           make: 'Accura',
         },
       });
@@ -280,8 +281,8 @@ describe('mocker', () => {
         schema,
       });
       const result = await mocker.mock(petTwoFragment, {
-        id: 1234,
-        breed: 'SHEPARD',
+        id: '1234',
+        breed: Breed.Shepard,
       });
 
       expect(result).toMatchSnapshot();
@@ -300,7 +301,7 @@ describe('mocker', () => {
       });
 
       await expect(() =>
-        mocker.mock(petThreeFragment, { id: 1234, breed: 'SHARK' })
+        mocker.mock(petThreeFragment, { id: '1234', breed: 'SHARK' as any })
       ).rejects.toMatchSnapshot();
     });
 
@@ -323,13 +324,13 @@ describe('mocker', () => {
         schema,
         typeGenerators: {
           ID() {
-            return 1234557;
+            return '1234557';
           },
         },
       });
       const result = await mocker.mock(personOneFragment, {
-        id: 1234,
-        pets: [{}, { id: 99999, name: 'Bob' }],
+        id: '1234',
+        pets: [{}, { id: '99999', name: 'Bob' }],
       });
 
       expect(result).toMatchSnapshot();
@@ -351,7 +352,7 @@ describe('mocker', () => {
         schema,
         typeGenerators: {
           ID() {
-            return 1234557;
+            return '1234557';
           },
         },
         fieldGenerators: {
@@ -363,7 +364,7 @@ describe('mocker', () => {
         },
       });
 
-      const result = await mocker.mock(carOneQuery, { id: 1234 });
+      const result = await mocker.mock(carOneQuery, { id: '1234' });
 
       expect(result).toMatchSnapshot();
     });
@@ -384,12 +385,14 @@ describe('mocker', () => {
         schema,
         typeGenerators: {
           ID() {
-            return 1234557;
+            return '1234557';
           },
         },
       });
 
-      const result = await mocker.mock(createOnePetMutation, { id: 1234 });
+      const result = await mocker.mock(createOnePetMutation, {
+        createPet: { id: '1234' },
+      });
 
       expect(result).toMatchSnapshot();
     });

--- a/packages/mocker/src/index.ts
+++ b/packages/mocker/src/index.ts
@@ -76,6 +76,17 @@ type QueryOrMutationWrapped<T> = {
   };
 };
 
+type IsObject<T> = T extends object
+  ? T extends any[]
+    ? never
+    : keyof T extends never
+    ? never
+    : true
+  : never;
+type DeepPartial<T> = IsObject<T> extends true
+  ? { [P in keyof T]?: DeepPartial<T[P]> }
+  : T;
+
 export class Mocker {
   private faker: Faker;
   private fieldGenerators: FieldGenerators;
@@ -108,7 +119,7 @@ export class Mocker {
     documentNode:
       | TypedDocumentNode<Document>
       | QueryOrMutationWrapped<Document>,
-    mockData: JSONObject
+    mockData: DeepPartial<Document>
   ): Promise<Document> {
     const definition =
       '__meta__' in documentNode


### PR DESCRIPTION
All values are optional as required fields will be mocked out. The screenshots below show autocomplete with typescript. As a result of this I fixed all the type errors that were in tests.

<img width="1046" alt="Screenshot 2023-06-29 at 11 32 44 AM" src="https://github.com/data-eden/data-eden/assets/1854811/78570323-dace-45d5-99fa-9115dde85279">
<img width="992" alt="Screenshot 2023-06-29 at 11 32 50 AM" src="https://github.com/data-eden/data-eden/assets/1854811/381d2f4d-35bb-47e9-bf2a-fc25c41a0a5d">
