### PR TITLE
feat: enable persisted or raw query execution

### DIFF
--- a/internal-packages/react-graphql-test-app/package.json
+++ b/internal-packages/react-graphql-test-app/package.json
@@ -7,6 +7,7 @@
     "build": "rm -rf dist && tsc && vite build",
     "codegen": "athena-codegen",
     "dev": "vite",
+    "dev:prod": "NODE_ENV=production vite",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/internal-packages/react-graphql-test-app/vite.config.ts
+++ b/internal-packages/react-graphql-test-app/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
       documents: ['**/*.graphql', '**/*.tsx'],
       extension: '.graphql.ts',
       disableSchemaTypesGeneration: false,
-      production: true,
+      production: process.env.NODE_ENV === 'production',
       resolver: function resolver(path) {
         const extensions = ['.tsx', '.jsx', '.js', '.ts'];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -586,6 +586,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@ardatan/sync-fetch": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
+      "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
@@ -5264,6 +5276,85 @@
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.0.tgz",
+      "integrity": "sha512-axQTbN5+Yxs1rJ6cWQBOfw3AEeC+fvIuZSfJLPLLvFJLj4pUm9fhxey/g6oQZAAQJqKPfw+tLDUQvnfvRK8Kmg==",
+      "dev": true,
+      "dependencies": {
+        "@ardatan/sync-fetch": "^0.0.1",
+        "@graphql-tools/utils": "^10.0.0",
+        "@whatwg-node/fetch": "^0.9.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@graphql-tools/utils": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.3.tgz",
+      "integrity": "sha512-6uO41urAEIs4sXQT2+CYGsUTkHkVo/2MpM/QjoHj6D6xoEF2woXHBpdAVi0HKIInDwZqWgEYOwIFez0pERxa1Q==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/events": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+      "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/fetch": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+      "integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
+      "dev": true,
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.4.8",
+        "urlpattern-polyfill": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/node-fetch": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.11.tgz",
+      "integrity": "sha512-JRMx/yrBW/PXUH+0EIurUIQtAsEMrHtZBBKv6b+YCK1yG7pMNqtkl5Z39Rynq8ysVc/I6yTtNwkCy9bz5To1vw==",
+      "dev": true,
+      "dependencies": {
+        "@whatwg-node/events": "^0.1.0",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "fast-url-parser": "^1.1.3",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/urlpattern-polyfill": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+      "dev": true
     },
     "node_modules/@graphql-tools/documents": {
       "version": "0.1.0",
@@ -33917,6 +34008,7 @@
         "@embroider/test-setup": "^2.0.2",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
+        "@graphql-tools/apollo-engine-loader": "^8.0.0",
         "@tsconfig/ember": "^2.0.0",
         "@types/ember": "^4.0.3",
         "@types/ember__application": "^4.0.5",
@@ -34492,6 +34584,15 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "@ardatan/sync-fetch": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
+      "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.1"
       }
     },
     "@babel/code-frame": {
@@ -35802,6 +35903,7 @@
         "@embroider/test-setup": "^2.0.2",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
+        "@graphql-tools/apollo-engine-loader": "^8.0.0",
         "@tsconfig/ember": "^2.0.0",
         "@types/ember": "^4.0.3",
         "@types/ember__application": "^4.0.5",
@@ -37873,6 +37975,66 @@
         "graphql-tag": "^2.11.0",
         "parse-filepath": "^1.0.2",
         "tslib": "~2.5.0"
+      }
+    },
+    "@graphql-tools/apollo-engine-loader": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.0.tgz",
+      "integrity": "sha512-axQTbN5+Yxs1rJ6cWQBOfw3AEeC+fvIuZSfJLPLLvFJLj4pUm9fhxey/g6oQZAAQJqKPfw+tLDUQvnfvRK8Kmg==",
+      "dev": true,
+      "requires": {
+        "@ardatan/sync-fetch": "^0.0.1",
+        "@graphql-tools/utils": "^10.0.0",
+        "@whatwg-node/fetch": "^0.9.0",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@graphql-tools/utils": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.3.tgz",
+          "integrity": "sha512-6uO41urAEIs4sXQT2+CYGsUTkHkVo/2MpM/QjoHj6D6xoEF2woXHBpdAVi0HKIInDwZqWgEYOwIFez0pERxa1Q==",
+          "dev": true,
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
+            "dset": "^3.1.2",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@whatwg-node/events": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+          "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+          "dev": true
+        },
+        "@whatwg-node/fetch": {
+          "version": "0.9.9",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
+          "integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
+          "dev": true,
+          "requires": {
+            "@whatwg-node/node-fetch": "^0.4.8",
+            "urlpattern-polyfill": "^9.0.0"
+          }
+        },
+        "@whatwg-node/node-fetch": {
+          "version": "0.4.11",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.11.tgz",
+          "integrity": "sha512-JRMx/yrBW/PXUH+0EIurUIQtAsEMrHtZBBKv6b+YCK1yG7pMNqtkl5Z39Rynq8ysVc/I6yTtNwkCy9bz5To1vw==",
+          "dev": true,
+          "requires": {
+            "@whatwg-node/events": "^0.1.0",
+            "busboy": "^1.6.0",
+            "fast-querystring": "^1.1.1",
+            "fast-url-parser": "^1.1.3",
+            "tslib": "^2.3.1"
+          }
+        },
+        "urlpattern-polyfill": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+          "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+          "dev": true
+        }
       }
     },
     "@graphql-tools/documents": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "clean": "find ./packages -name 'tsconfig.build.tsbuildinfo' -delete && find ./packages \\( -name 'node_modules' -prune \\) -o \\( -name 'dist' -type d -prune -exec rm -rf '{}' + \\)",
-    "build": "npm run clean && npm run build -w @data-eden/shared-test-utilities -w @data-eden/cache -w @data-eden/network -w @data-eden/athena -w @data-eden/react -w @data-eden/codegen -w @data-eden/mocker",
+    "build": "npm run clean && npm run build -w @data-eden/shared-test-utilities -w @data-eden/cache -w @data-eden/network -w @data-eden/codegen -w @data-eden/athena -w @data-eden/react -w @data-eden/mocker",
     "build:watch": "npm run build --- --watch",
     "prepublish": "npm run build",
     "postinstall": "patch-package",

--- a/packages/athena/src/signal-cache.ts
+++ b/packages/athena/src/signal-cache.ts
@@ -76,8 +76,11 @@ export class SignalCache {
 
   // Associate an operation with its root entities. This method does *not* also store the actual
   // entities, it is intended solely tracking the top-level links for a given operation
-  storeOperation(
-    operation: GraphQLOperation,
+  storeOperation<
+    Data extends object = object,
+    Variables extends DefaultVariables = DefaultVariables
+  >(
+    operation: GraphQLOperation<Data, Variables>,
     links?: Map<PropertyPath, CacheKey>
   ) {
     const linksObj: Link = links

--- a/packages/athena/src/types.ts
+++ b/packages/athena/src/types.ts
@@ -1,8 +1,9 @@
 import type { buildCache } from '@data-eden/cache';
 import type { SIGNAL } from './signal-proxy.js';
-import type { DocumentNode, GraphQLError } from 'graphql';
+import type { GraphQLError } from 'graphql';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import type { Primitive } from 'type-fest';
+import type { CodegenDocument } from '@data-eden/codegen';
 
 export type DataEdenCache = ReturnType<typeof buildCache>;
 
@@ -12,8 +13,9 @@ export type DefaultRecord = Record<string, object>;
 export type DocumentInput<
   Data = Record<string, any>,
   Variables = DefaultVariables
-> = string | DocumentNode | TypedDocumentNode<Data, Variables>;
-
+> = TypedDocumentNode<Data, Variables> & {
+  __meta__?: CodegenDocument;
+};
 export interface ReactiveSignal<T> {
   value: T;
 }
@@ -38,7 +40,7 @@ export interface GraphQLOperation<
       sha256Hash: string;
     };
   };
-  fetchMore?: boolean;
+  fetchMore?: boolean | undefined;
 }
 
 export interface GraphQLResponse<Data extends object = object> {

--- a/packages/codegen/__tests__/bin.test.ts
+++ b/packages/codegen/__tests__/bin.test.ts
@@ -67,12 +67,20 @@ describe('bin', () => {
         export const ChatsDocument = {\\"__meta__\\":{\\"queryId\\":\\"a0cd151991e13b081cc250bf42218547f2c8e340282b90c1f7fe36c332de3416\\"}} as unknown as DocumentNode<ChatsQuery, ChatsQueryVariables>;"
       `);
 
-    expect(await read('query-identifiers.json')).toMatchInlineSnapshot(`
-      "{
-        \\"d17490e4b9ac1f7c227df3da6e5c5cdc6686b24d7194c0cb1bc29a8189a58f5c\\": \\"fragment UserFields on User { id role username } query findUser($userId: ID!) { user(id: $userId) { __typename ...UserFields } }\\",
-        \\"a0cd151991e13b081cc250bf42218547f2c8e340282b90c1f7fe36c332de3416\\": \\"fragment ChatFields on Chat { id messages { content id user { id username } } users { ...UserFields } } fragment UserFields on User { id role username } query chats($userId: ID!) { myChats { __typename ...ChatFields } }\\"
-      }"
-    `);
+    const cwdRegex = new RegExp(process.cwd(), 'g');
+    expect((await read('query-identifiers.json')).replace(cwdRegex, ''))
+      .toMatchInlineSnapshot(`
+        "{
+          \\"d17490e4b9ac1f7c227df3da6e5c5cdc6686b24d7194c0cb1bc29a8189a58f5c\\": {
+            \\"fileSource\\": \\"fragment UserFields on User { id role username } query findUser($userId: ID!) { user(id: $userId) { __typename ...UserFields } }\\",
+            \\"filePath\\": \\"/__tests__/__graphql-project/queries/find-user.graphql\\"
+          },
+          \\"a0cd151991e13b081cc250bf42218547f2c8e340282b90c1f7fe36c332de3416\\": {
+            \\"fileSource\\": \\"fragment ChatFields on Chat { id messages { content id user { id username } } users { ...UserFields } } fragment UserFields on User { id role username } query chats($userId: ID!) { myChats { __typename ...ChatFields } }\\",
+            \\"filePath\\": \\"/__tests__/__graphql-project/queries/my-chats.graphql\\"
+          }
+        }"
+      `);
 
     expect(await read('schema.graphql.ts')).toMatchInlineSnapshot(`
       "export type Maybe<T> = T | null;

--- a/packages/codegen/__tests__/codegen.test.ts
+++ b/packages/codegen/__tests__/codegen.test.ts
@@ -114,12 +114,21 @@ describe('codegen', () => {
         export const ChatsDocument = {\\"__meta__\\":{\\"queryId\\":\\"a0cd151991e13b081cc250bf42218547f2c8e340282b90c1f7fe36c332de3416\\"}} as unknown as DocumentNode<ChatsQuery, ChatsQueryVariables>;"
       `);
 
-    expect(await read('query-identifiers.json')).toMatchInlineSnapshot(`
-      "{
-        \\"d17490e4b9ac1f7c227df3da6e5c5cdc6686b24d7194c0cb1bc29a8189a58f5c\\": \\"fragment UserFields on User { id role username } query findUser($userId: ID!) { user(id: $userId) { __typename ...UserFields } }\\",
-        \\"a0cd151991e13b081cc250bf42218547f2c8e340282b90c1f7fe36c332de3416\\": \\"fragment ChatFields on Chat { id messages { content id user { id username } } users { ...UserFields } } fragment UserFields on User { id role username } query chats($userId: ID!) { myChats { __typename ...ChatFields } }\\"
-      }"
-    `);
+    const cwdRegex = new RegExp(process.cwd(), 'g');
+
+    expect((await read('query-identifiers.json')).replace(cwdRegex, ''))
+      .toMatchInlineSnapshot(`
+        "{
+          \\"d17490e4b9ac1f7c227df3da6e5c5cdc6686b24d7194c0cb1bc29a8189a58f5c\\": {
+            \\"fileSource\\": \\"fragment UserFields on User { id role username } query findUser($userId: ID!) { user(id: $userId) { __typename ...UserFields } }\\",
+            \\"filePath\\": \\"/__tests__/__graphql-project/queries/find-user.graphql\\"
+          },
+          \\"a0cd151991e13b081cc250bf42218547f2c8e340282b90c1f7fe36c332de3416\\": {
+            \\"fileSource\\": \\"fragment ChatFields on Chat { id messages { content id user { id username } } users { ...UserFields } } fragment UserFields on User { id role username } query chats($userId: ID!) { myChats { __typename ...ChatFields } }\\",
+            \\"filePath\\": \\"/__tests__/__graphql-project/queries/my-chats.graphql\\"
+          }
+        }"
+      `);
 
     expect(await read('schema.graphql.ts')).toMatchSnapshot();
   });

--- a/packages/codegen/src/generate-document-files.ts
+++ b/packages/codegen/src/generate-document-files.ts
@@ -1,6 +1,6 @@
 import type { Types } from '@graphql-codegen/plugin-helpers';
 import type { DocumentNode, GraphQLSchema } from 'graphql';
-import { parse } from 'graphql';
+import { Source, parse } from 'graphql';
 import { readFileSync } from 'node:fs';
 import { extractDefinitions } from './gql/extract-definitions.js';
 import { resolveForeignReferences } from './gql/foreign-ref-resolver.js';
@@ -75,7 +75,7 @@ function handleGraphQLFiles(
     try {
       const contents = readFileSync(path, 'utf-8');
       const parsed = rewriteAst(
-        parse(contents),
+        parse(new Source(contents, path)),
         schema,
         primaryKeyAlias
       ) as DocumentNode;

--- a/packages/codegen/src/gql/output-operations.ts
+++ b/packages/codegen/src/gql/output-operations.ts
@@ -1,4 +1,4 @@
-import { parse, print, visit } from 'graphql';
+import { Source, parse, print, visit } from 'graphql';
 import type { FragmentDefinitionNode } from 'graphql/language/index.js';
 import type { Types } from '@graphql-codegen/plugin-helpers';
 
@@ -154,7 +154,7 @@ export function outputOperations(
     return {
       location: filePath,
       rawSDL: opStr,
-      document: parse(opStr),
+      document: parse(new Source(opStr, filePath)),
     };
   });
 }

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -1,5 +1,5 @@
 export { athenaCodegen } from './codegen.js';
-export type { OutputFile, Source, Resolver } from './types.js';
+export type { OutputFile, Source, Resolver, CodegenDocument } from './types.js';
 export { generateDocumentFiles } from './generate-document-files.js';
 export { generateSchemaTypes } from './generate-schema-types.js';
 export { binMain } from './bin.js';

--- a/packages/codegen/src/types.ts
+++ b/packages/codegen/src/types.ts
@@ -1,5 +1,10 @@
 import type { DocumentNode, GraphQLSchema } from 'graphql';
 
+export interface CodegenDocument {
+  queryId: string;
+  $DEBUG?: { contents: string; ast: DocumentNode };
+}
+
 export interface Source {
   document?: DocumentNode;
   schema?: GraphQLSchema;

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -39,6 +39,7 @@
     "@embroider/test-setup": "^2.0.2",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "@graphql-tools/apollo-engine-loader": "^8.0.0",
     "@tsconfig/ember": "^2.0.0",
     "@types/ember": "^4.0.3",
     "@types/ember__application": "^4.0.5",

--- a/packages/react/src/use-query.ts
+++ b/packages/react/src/use-query.ts
@@ -67,14 +67,14 @@ export function useQuery<
   query: DocumentInput<Data, Variables>,
   variables?: Variables,
   options: UseQueryOptions<Data> = {}
-): QueryResponse<Data> {
+): QueryResponse<Data, Variables> {
   const client = useAthenaClient();
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<Data | undefined>(options.initialData);
   const [error, setError] = useState<ClientError>();
   const [, forceUpdate] = useReducer(safeIncrement, 0);
   const reactionRef = useRef<Reaction>();
-  const vars = useVariables(variables);
+  const vars = useVariables<Variables>(variables);
   const { initialData } = options;
 
   const trackDeps = useCallback(
@@ -113,13 +113,14 @@ export function useQuery<
     }, EMPTY);
   }
 
-  const refetch = useCallback(async function <
-    Variables extends DefaultVariables = DefaultVariables
-  >(variables?: Variables, options?: QueryOptions) {
+  const refetch = useCallback(async function (
+    variables?: Variables,
+    options?: QueryOptions
+  ) {
     setLoading(true);
 
     try {
-      const { data, error } = await client.query<Data>(
+      const { data, error } = await client.query<Data, Variables>(
         query,
         // if new variables were passed in, we use those, otherwise we execute with the original
         // set
@@ -141,13 +142,11 @@ export function useQuery<
   EMPTY);
 
   const fetchMore = useCallback(
-    async function <Variables extends DefaultVariables = DefaultVariables>(
-      variables?: Variables
-    ) {
+    async function (variables?: Variables) {
       setLoading(true);
 
       try {
-        const { data, error } = await client.query<Data>(
+        const { data, error } = await client.query<Data, Variables>(
           query,
           // if new variables were passed in, we use those, otherwise we execute with the original
           // set

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,9 @@
   "files": [],
   "references": [
     {
+      "path": "./packages/codegen"
+    },
+    {
       "path": "./packages/athena"
     },
     {
@@ -12,9 +15,6 @@
     },
     {
       "path": "./packages/ember"
-    },
-    {
-      "path": "./packages/codegen"
     },
     {
       "path": "./packages/mocker"


### PR DESCRIPTION
- updates Athena to handle token logic based on available fields to distinguish between persisted or raw query execution
- adds more information to the query-identifiers.json file to assist in figuring out where queries originate from
- breaking: no longer supports raw strings as operations, must be a operation token

## Prod

> Test this in internal-packages/react-graphql-test-app (this command enables process.env.NODE_ENV=production)

```
npm run dev:prod
```

<img width="1840" alt="Screenshot 2023-07-19 at 8 29 17 PM" src="https://github.com/data-eden/data-eden/assets/1854811/f8109194-ae24-4e81-94e9-d408444b31e1">

## Dev

> Test this in internal-packages/react-graphql-test-app

```
npm run dev
```

<img width="1840" alt="Screenshot 2023-07-19 at 8 28 28 PM" src="https://github.com/data-eden/data-eden/assets/1854811/1ccaa753-c6a2-497a-ab69-c59da1c28f58">
