### PR TITLE
Fix faker float deprecation warning

### DIFF
--- a/packages/mocker/src/index.ts
+++ b/packages/mocker/src/index.ts
@@ -43,7 +43,7 @@ const defaultTypeGenerators: TypeGenerators = {
       )) as unknown as JSONValue;
   },
   Float(faker: Faker) {
-    const randomNum = faker.datatype.number({
+    const randomNum = faker.number.float({
       min: 0,
       max: 92233720368547,
       precision: 0.01,


### PR DESCRIPTION
[Faker float guide](https://fakerjs.dev/api/number.html#float)

`[@faker-js/faker]: faker.datatype.number() is deprecated since v8.0 and will be removed in v9.0. Please use faker.number.int() instead.`