### PR TITLE
feat: handle field alias mocking

### DIFF
--- a/packages/mocker/__tests__/__snapshots__/mocker.test.ts.snap
+++ b/packages/mocker/__tests__/__snapshots__/mocker.test.ts.snap
@@ -1,8 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`mocker > fragments > fragment with aliased data 1`] = `
+{
+  "carMake": "accura tsx",
+  "id": "1234",
+}
+`;
+
 exports[`mocker > fragments > fragment with default data 1`] = `
 {
-  "id": 1234,
+  "id": "1234",
   "make": "whose nor",
 }
 `;

--- a/packages/mocker/__tests__/mocker.test.ts
+++ b/packages/mocker/__tests__/mocker.test.ts
@@ -2,13 +2,12 @@ import { describe, test, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-import { print } from 'graphql';
-
 import { gql } from '@data-eden/codegen/gql';
 
 import { Mocker } from '@data-eden/mocker';
 import {
   CarOneFragment,
+  CarOneHalfFragment,
   CarTwoFragment,
   CarThreeFragment,
   CarFourFragment,
@@ -44,7 +43,24 @@ describe('mocker', () => {
       `;
 
       const mocker = new Mocker({ schema });
-      const result = mocker.mock(carOneFragment, { id: 1234 });
+      const result = mocker.mock(carOneFragment, { id: '1234' });
+
+      expect(result).toMatchSnapshot();
+    });
+
+    test('fragment with aliased data', async () => {
+      const carOneHalfFragment = gql<CarOneHalfFragment>`
+        fragment carOneHalf on Car {
+          id
+          carMake: make
+        }
+      `;
+
+      const mocker = new Mocker({ schema });
+      const result = mocker.mock(carOneHalfFragment, {
+        id: '1234',
+        carMake: 'accura tsx',
+      });
 
       expect(result).toMatchSnapshot();
     });

--- a/packages/mocker/src/index.ts
+++ b/packages/mocker/src/index.ts
@@ -283,8 +283,9 @@ export class Mocker {
         throw new Error(
           'Fragment spreads are not supported, please resolve all fragments spreads before trying to mock.'
         );
-      } else {
-        const fieldName = field.name.value;
+      } else if (field.kind === 'Field') {
+        const fieldName = field.alias ? field.alias.value : field.name.value;
+        const originalFieldName = field.name.value;
 
         if (fieldName === '__typename') {
           result[fieldName] = type.name;
@@ -293,14 +294,14 @@ export class Mocker {
             !type ||
             !('getFields' in type) ||
             !type.getFields ||
-            !type.getFields()[fieldName]
+            !type.getFields()[originalFieldName]
           ) {
             throw new Error(
-              `Field ${fieldName} does not exist in the schema for type ${type?.name}`
+              `Field ${originalFieldName} does not exist in the schema for type ${type?.name}`
             );
           }
 
-          let fieldType = type.getFields()[fieldName].type;
+          let fieldType = type.getFields()[originalFieldName].type;
 
           // If it's a NonNull type, unwrap it
           if (fieldType instanceof GraphQLNonNull) {
@@ -339,7 +340,7 @@ export class Mocker {
                   (item) =>
                     this.generateMockDataForType(
                       type.name,
-                      fieldName,
+                      originalFieldName,
                       elementType,
                       item
                     )


### PR DESCRIPTION
properly checks for the field node name taking into account if it is an alias.