### PR TITLE
fix transaction merging

### DIFF
--- a/packages/athena/vitest.config.ts
+++ b/packages/athena/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@data-eden/athena': resolve(__dirname, './src'),
+      '@data-eden/cache': resolve(__dirname, '../cache/src'),
       '@data-eden/mocker': resolve(__dirname, '../mocker/src'),
     },
   },

--- a/packages/cache/__tests__/index-test.ts
+++ b/packages/cache/__tests__/index-test.ts
@@ -281,6 +281,10 @@ describe('@data-eden/cache', function () {
 
       await tx.merge('book:3', { 'book:3': { title: 'New Merged book' } });
       await tx.merge('book:1', { 'book:1': { title: 'Conflict', sub: 'j3' } });
+      await tx.merge('book:4', {
+        'book:4': { title: 'New book', sub: 'wat', newField: 'blah' },
+      });
+      await tx.merge('book:4', { 'book:4': { title: 'New book', sub: 'foo' } });
 
       // Validate Transactional entries
       expect(await tx.get('book:1')).toEqual({
@@ -316,6 +320,10 @@ describe('@data-eden/cache', function () {
       });
       expect(await cache.get('book:3')).toEqual({
         'book:3': { title: 'New Merged book' },
+      });
+
+      expect(await cache.get('book:4')).toEqual({
+        'book:4': { title: 'New book', sub: 'foo', newField: 'blah' },
       });
     });
 

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -586,7 +586,7 @@ const defaultRetensionStrategy = async function retainAllRevisions<
   commitingRevisionTx.cache.appendRevisions(id, [...revisions]);
 };
 
-const defaultMergeStrategy = function deepMergeStratey<
+const defaultMergeStrategy = function deepMergeStrategy<
   CacheKeyRegistry extends DefaultRegistry,
   Key extends keyof CacheKeyRegistry
 >(

--- a/packages/cache/src/live-transaction.ts
+++ b/packages/cache/src/live-transaction.ts
@@ -146,8 +146,12 @@ export class LiveCacheTransactionImpl<
     this.#revisionContext = options?.revisionContext;
     const mergeStrategy = this.#getMergeStrategy(options?.entityMergeStrategy);
 
-    // get current cache value within this transaction
-    const currentValue = await this.#originalCacheReference.get(cacheKey);
+    // get current cache value within this transaction, and fall back to underlying cache if no
+    // value exists in the current transaction
+    const currentValue =
+      (await this.get(cacheKey)) ||
+      (await this.#originalCacheReference.get(cacheKey));
+
     const localRevisionsByEntry = this.getLocalRevisionsByEntry(cacheKey);
 
     let revisionNumber =


### PR DESCRIPTION
updates the transaction merging behavior to look for prior entities in the transaction itself as well as the cache so that we don’t accidentally overwrite multiple instances of the same entry in the same transaction