### PR TITLE
feat: enable field injection for special cases in codegen

### DIFF
--- a/packages/codegen/__tests__/__snapshots__/codegen.test.ts.snap
+++ b/packages/codegen/__tests__/__snapshots__/codegen.test.ts.snap
@@ -161,6 +161,29 @@ export enum Role {
 "
 `;
 
+exports[`codegen > with gql tags and fieldInjection 1`] = `
+"export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  Date: any;
+};
+
+export enum Role {
+  User = 'USER',
+  Admin = 'ADMIN'
+}
+"
+`;
+
 exports[`codegen > with graphql files (production) 3`] = `
 "export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;

--- a/packages/codegen/__tests__/codegen.test.ts
+++ b/packages/codegen/__tests__/codegen.test.ts
@@ -225,6 +225,47 @@ describe('codegen', () => {
     `);
   });
 
+  test('with gql tags and fieldInjection', async () => {
+    project = await createFixtures(gqlFilesMap);
+
+    await athenaCodegen({
+      schemaPath: 'schema.graphql',
+      documents: [`${project.baseDir}/**/*.tsx`],
+      baseDir: project.baseDir,
+      extension: '.graphql.ts',
+      disableSchemaTypesGeneration: false,
+      fieldInjection: {
+        User: {
+          name: 'role',
+          alias: 'userRole',
+        },
+      },
+      production: false,
+    });
+
+    expect(await read('schema.graphql.ts')).toMatchSnapshot();
+
+    expect(await read('__generated/User.graphql.ts')).toMatchInlineSnapshot(`
+      "import type * as Types from '../schema.graphql.js';
+
+      import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+      export type UserFieldsFragment = { __typename: 'User', id: string, username: string, role: Types.Role, userRole: Types.Role };
+
+      export type FindUserQueryVariables = Types.Exact<{
+        userId: Types.Scalars['ID'];
+      }>;
+
+
+      export type FindUserQuery = { __typename: 'Query', user?: (
+          { __typename: 'User', userRole: Types.Role }
+          & UserFieldsFragment
+        ) | null };
+
+      export const UserFieldsFragmentDoc = {\\"kind\\":\\"Document\\",\\"definitions\\":[{\\"kind\\":\\"FragmentDefinition\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"UserFields\\"},\\"typeCondition\\":{\\"kind\\":\\"NamedType\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"User\\"}},\\"selectionSet\\":{\\"kind\\":\\"SelectionSet\\",\\"selections\\":[{\\"kind\\":\\"Field\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"__typename\\"}},{\\"kind\\":\\"Field\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"id\\"}},{\\"kind\\":\\"Field\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"username\\"}},{\\"kind\\":\\"Field\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"role\\"}},{\\"kind\\":\\"Field\\",\\"alias\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"userRole\\"},\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"role\\"}}]}}]} as unknown as DocumentNode<UserFieldsFragment, unknown>;
+      export const FindUserDocument = {\\"__meta__\\":{\\"queryId\\":\\"3a9f3082d5081da4492ebd6b21557e04a19accc62db2d158c4675fb54bd3b619\\",\\"$DEBUG\\":{\\"contents\\":\\"fragment UserFields on User { __typename id role userRole: role username } query findUser($userId: ID!) { __typename user(id: $userId) { __typename userRole: role ...UserFields } }\\",\\"ast\\":{\\"kind\\":\\"Document\\",\\"definitions\\":[{\\"kind\\":\\"OperationDefinition\\",\\"operation\\":\\"query\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"findUser\\"},\\"variableDefinitions\\":[{\\"kind\\":\\"VariableDefinition\\",\\"variable\\":{\\"kind\\":\\"Variable\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"userId\\"}},\\"type\\":{\\"kind\\":\\"NonNullType\\",\\"type\\":{\\"kind\\":\\"NamedType\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"ID\\"}}}}],\\"selectionSet\\":{\\"kind\\":\\"SelectionSet\\",\\"selections\\":[{\\"kind\\":\\"Field\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"__typename\\"}},{\\"kind\\":\\"Field\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"user\\"},\\"arguments\\":[{\\"kind\\":\\"Argument\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"id\\"},\\"value\\":{\\"kind\\":\\"Variable\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"userId\\"}}}],\\"selectionSet\\":{\\"kind\\":\\"SelectionSet\\",\\"selections\\":[{\\"kind\\":\\"Field\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"__typename\\"}},{\\"kind\\":\\"FragmentSpread\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"UserFields\\"}},{\\"kind\\":\\"Field\\",\\"alias\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"userRole\\"},\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"role\\"}}]}}]}},{\\"kind\\":\\"FragmentDefinition\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"UserFields\\"},\\"typeCondition\\":{\\"kind\\":\\"NamedType\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"User\\"}},\\"selectionSet\\":{\\"kind\\":\\"SelectionSet\\",\\"selections\\":[{\\"kind\\":\\"Field\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"__typename\\"}},{\\"kind\\":\\"Field\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"id\\"}},{\\"kind\\":\\"Field\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"username\\"}},{\\"kind\\":\\"Field\\",\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"role\\"}},{\\"kind\\":\\"Field\\",\\"alias\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"userRole\\"},\\"name\\":{\\"kind\\":\\"Name\\",\\"value\\":\\"role\\"}}]}}]}}}} as unknown as DocumentNode<FindUserQuery, FindUserQueryVariables>;"
+    `);
+  });
+
   test('with gql tags (production)', async () => {
     project = await createFixtures(gqlFilesMap);
 

--- a/packages/codegen/src/codegen.ts
+++ b/packages/codegen/src/codegen.ts
@@ -43,6 +43,7 @@ export async function athenaCodegen({
   production,
   resolver,
   primaryKeyAlias,
+  fieldInjection,
 }: CodegenConfig): Promise<void> {
   const startTime = hrtime.bigint();
 
@@ -105,6 +106,7 @@ export async function athenaCodegen({
       graphqlSchema,
       paths,
       primaryKeyAlias ?? null,
+      fieldInjection ?? null,
       defaultResolver
     );
 

--- a/packages/codegen/src/gql/extract-definitions.ts
+++ b/packages/codegen/src/gql/extract-definitions.ts
@@ -4,13 +4,18 @@ import type { GraphQLSchema } from 'graphql';
 import { readFileSync } from 'node:fs';
 import { createExtractor } from './extractor.js';
 import type { Definition, UnresolvedFragment } from './types.js';
-import { type PrimaryKeyAlias, type Resolver } from '../types.js';
+import {
+  type FieldInjection,
+  type PrimaryKeyAlias,
+  type Resolver,
+} from '../types.js';
 
 export function extractDefinitions(
   schema: GraphQLSchema,
   fileName: string,
   resolver: Resolver,
-  primaryKeyAlias: PrimaryKeyAlias | null
+  primaryKeyAlias: PrimaryKeyAlias | null,
+  fieldInjection: FieldInjection | null
 ) {
   const document = readFileSync(fileName, 'utf-8');
   const parsed = parse(document, {
@@ -29,7 +34,14 @@ export function extractDefinitions(
 
   traverse(
     parsed,
-    createExtractor(schema, fileName, definitions, resolver, primaryKeyAlias)
+    createExtractor(
+      schema,
+      fileName,
+      definitions,
+      resolver,
+      primaryKeyAlias,
+      fieldInjection
+    )
   );
 
   const exportedDefinitionMap = new Map<

--- a/packages/codegen/src/gql/extractor.ts
+++ b/packages/codegen/src/gql/extractor.ts
@@ -32,7 +32,7 @@ import type {
 } from './types.js';
 import { createHash } from 'crypto';
 import { existsSync } from 'node:fs';
-import type { PrimaryKeyAlias } from '../types.js';
+import type { FieldInjection, PrimaryKeyAlias } from '../types.js';
 import { type Resolver } from '../types.js';
 import { rewriteAst } from '../utils.js';
 
@@ -176,7 +176,8 @@ export function createExtractor(
   filePath: string,
   definitions: Array<Definition>,
   resolver: Resolver,
-  primaryKeyAlias: PrimaryKeyAlias | null
+  primaryKeyAlias: PrimaryKeyAlias | null,
+  fieldInjection: FieldInjection | null
 ) {
   const localDefinitionDeclaratorMap = new Map<
     NodePath<VariableDeclarator>,
@@ -253,7 +254,8 @@ export function createExtractor(
       const documentNode = rewriteAst(
         graphqlParse(generatedDefinitionString),
         schema,
-        primaryKeyAlias
+        primaryKeyAlias,
+        fieldInjection
       ) as DocumentNode;
       const defAst = getDefinition(documentNode, filePath);
       let def: Definition;

--- a/packages/codegen/src/types.ts
+++ b/packages/codegen/src/types.ts
@@ -28,6 +28,13 @@ export type PrimaryKeyAlias = {
   };
 };
 
+export type FieldInjection = {
+  [key: string]: {
+    name: string;
+    alias?: string;
+  };
+};
+
 export type CodegenConfig = {
   schemaPath: string;
   documents: Array<string>;
@@ -39,6 +46,7 @@ export type CodegenConfig = {
   hash?: (document: DocumentNode) => string;
   resolver?: Resolver;
   primaryKeyAlias?: PrimaryKeyAlias;
+  fieldInjection?: FieldInjection;
 };
 
 export type OutputFile = {


### PR DESCRIPTION
For special casing injection you can now do 

```js
await athenaCodegen({
      schemaPath: 'schema.graphql',
      documents: [`${project.baseDir}/**/*.tsx`],
      baseDir: project.baseDir,
      extension: '.graphql.ts',
      disableSchemaTypesGeneration: false,
      fieldInjection: {
        User: {
          name: 'role',
          alias: 'userRole',
        },
      },
      production: false,
    });
```

This will most likely supersede the need for primaryKey injection as you can use this instead, will deprecate that in a later PR.